### PR TITLE
Fix catch legacy replay positions not being relative to playfield size

### DIFF
--- a/osu.Game.Rulesets.Catch/Replays/CatchReplayFrame.cs
+++ b/osu.Game.Rulesets.Catch/Replays/CatchReplayFrame.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Replays.Legacy;
 using osu.Game.Rulesets.Replays.Types;
@@ -26,8 +27,7 @@ namespace osu.Game.Rulesets.Catch.Replays
 
         public void ConvertFrom(LegacyReplayFrame legacyFrame, Beatmap beatmap)
         {
-            // Todo: This needs to be re-scaled
-            Position = legacyFrame.Position.X;
+            Position = legacyFrame.Position.X / CatchPlayfield.BASE_WIDTH;
             Dashing = legacyFrame.ButtonState == ReplayButtonState.Left1;
         }
     }


### PR DESCRIPTION
Resolves ppy/osu#2140

Prereqs:
- [ ] ppy/osu#2137

Tested with Roido's play on https://osu.ppy.sh/b/1475261&m=2 .