### PR TITLE
Split pick toggle into selected/deselected

### DIFF
--- a/osu.Game/Online/Multiplayer/IMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/IMultiplayerClient.cs
@@ -186,8 +186,13 @@ namespace osu.Game.Online.Multiplayer
         Task MatchmakingQueueStatusChanged(MatchmakingQueueStatus status);
 
         /// <summary>
-        /// A user has toggled their selection.
+        /// The user has raised a candidate playlist item to be played.
         /// </summary>
-        Task MatchmakingSelectionToggled(int userId, long playlistItemId);
+        Task MatchmakingItemSelected(int userId, long playlistItemId);
+
+        /// <summary>
+        /// The user has removed a candidate playlist item.
+        /// </summary>
+        Task MatchmakingItemDeselected(int userId, long playlistItemId);
     }
 }

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -124,7 +124,8 @@ namespace osu.Game.Online.Multiplayer
         public event Action<long>? MatchmakingRoomReady;
         public event Action<MatchmakingLobbyStatus>? MatchmakingLobbyStatusChanged;
         public event Action<MatchmakingQueueStatus>? MatchmakingQueueStatusChanged;
-        public event Action<int, long>? MatchmakingSelectionToggled;
+        public event Action<int, long>? MatchmakingItemSelected;
+        public event Action<int, long>? MatchmakingItemDeselected;
         public event Action<MatchRoomState>? MatchRoomStateChanged;
 
         /// <summary>
@@ -1076,11 +1077,22 @@ namespace osu.Game.Online.Multiplayer
             return Task.CompletedTask;
         }
 
-        Task IMultiplayerClient.MatchmakingSelectionToggled(int userId, long playlistItemId)
+        Task IMultiplayerClient.MatchmakingItemSelected(int userId, long playlistItemId)
         {
             Scheduler.Add(() =>
             {
-                MatchmakingSelectionToggled?.Invoke(userId, playlistItemId);
+                MatchmakingItemSelected?.Invoke(userId, playlistItemId);
+                RoomUpdated?.Invoke();
+            });
+
+            return Task.CompletedTask;
+        }
+
+        Task IMultiplayerClient.MatchmakingItemDeselected(int userId, long playlistItemId)
+        {
+            Scheduler.Add(() =>
+            {
+                MatchmakingItemDeselected?.Invoke(userId, playlistItemId);
                 RoomUpdated?.Invoke();
             });
 

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -78,7 +78,8 @@ namespace osu.Game.Online.Multiplayer
                     connection.On<long>(nameof(IMultiplayerClient.MatchmakingRoomReady), ((IMultiplayerClient)this).MatchmakingRoomReady);
                     connection.On<MatchmakingLobbyStatus>(nameof(IMultiplayerClient.MatchmakingLobbyStatusChanged), ((IMultiplayerClient)this).MatchmakingLobbyStatusChanged);
                     connection.On<MatchmakingQueueStatus>(nameof(IMultiplayerClient.MatchmakingQueueStatusChanged), ((IMultiplayerClient)this).MatchmakingQueueStatusChanged);
-                    connection.On<int, long>(nameof(IMultiplayerClient.MatchmakingSelectionToggled), ((IMultiplayerClient)this).MatchmakingSelectionToggled);
+                    connection.On<int, long>(nameof(IMultiplayerClient.MatchmakingItemSelected), ((IMultiplayerClient)this).MatchmakingItemSelected);
+                    connection.On<int, long>(nameof(IMultiplayerClient.MatchmakingItemDeselected), ((IMultiplayerClient)this).MatchmakingItemDeselected);
                 };
 
                 IsConnected.BindTo(connector.IsConnected);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Pick/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Pick/PickScreen.cs
@@ -48,7 +48,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick
 
             selectionGrid.ItemSelected += item => client.MatchmakingToggleSelection(item.ID);
 
-            client.MatchmakingSelectionToggled += selectionToggled;
+            client.MatchmakingItemSelected += onItemSelected;
+            client.MatchmakingItemDeselected += onItemDeselected;
         }
 
         private void onItemAdded(MultiplayerPlaylistItem item) => Scheduler.Add(() => selectionGrid.AddItem(item));
@@ -59,11 +60,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Pick
                 selectionGrid.RemoveItem(item.ID);
         });
 
-        private void selectionToggled(int userId, long itemId)
+        private void onItemSelected(int userId, long itemId)
         {
             var user = client.Room!.Users.First(it => it.UserID == userId).User!;
+            selectionGrid.SetUserSelection(user, itemId, true);
+        }
 
-            selectionGrid.SetUserSelection(user, itemId, isOwnUser: api.LocalUser.Value.Id == userId);
+        private void onItemDeselected(int userId, long itemId)
+        {
+            var user = client.Room!.Users.First(it => it.UserID == userId).User!;
+            selectionGrid.SetUserSelection(user, itemId, false);
         }
 
         private void onItemRemoved(long itemId) => Scheduler.Add(() => selectionGrid.RemoveItem(itemId));


### PR DESCRIPTION
- Split `MatchmakingSelectionToggled` into `MatchmakingItemSelected` and `MatchmakingItemDeselected`.
- Removed client-side validation of state (`userSelection`).
- Enforced single user pick in `TestMultiplayerClient` to match server implementation.

The client should, in general, perform little-to-no validation on expectations. The server may change at any point for example to allow a user to pick multiple items via custom room settings.

cc/ @minetoblend