### PR TITLE
Fix placement assignment on users with missing rounds

### DIFF
--- a/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/Matchmaking/MatchmakingRoomState.cs
@@ -95,7 +95,7 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.Matchmaking
             }
 
             int i = 1;
-            foreach (var user in Users.Order(new MatchmakingUserComparer()))
+            foreach (var user in Users.Order(new MatchmakingUserComparer(Round)))
                 user.Placement = i++;
         }
     }


### PR DESCRIPTION
Users that haven't played a round are at a natural disadvantage to other players that have played the round.

- Didn't consider the case where _both_ compared players haven't played a round.
- Didn't consider the case where players played later rounds.
- Didn't correctly disadvantage players without a round, instead falling back to the user-id unlikely-tiebreaker.
