### PR TITLE
Refactor MatchmakingScreenStack to be responsible for matchmaking layout

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreenStack.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingScreenStack.cs
@@ -13,7 +13,6 @@ using osu.Game.Online.Rooms;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Screens;
 using osu.Game.Tests.Visual.Multiplayer;
-using osuTK;
 
 namespace osu.Game.Tests.Visual.Matchmaking
 {
@@ -47,7 +46,6 @@ namespace osu.Game.Tests.Visual.Matchmaking
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(0.7f)
                 };
             });
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
@@ -32,7 +32,7 @@ using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking
 {
-    public class MatchmakingScreen : OsuScreen
+    public partial class MatchmakingScreen : OsuScreen
     {
         /// <summary>
         /// Padding between rows of the content.
@@ -115,30 +115,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                                                 RelativeSizeAxes = Axes.Both,
                                                 Colour = Color4Extensions.FromHex(@"3e3a44") // Temporary.
                                             },
-                                            new GridContainer
-                                            {
-                                                RelativeSizeAxes = Axes.Both,
-                                                Padding = new MarginPadding(10),
-                                                RowDimensions =
-                                                [
-                                                    new Dimension(),
-                                                    new Dimension(GridSizeMode.Absolute, row_padding),
-                                                    new Dimension(GridSizeMode.AutoSize)
-                                                ],
-                                                Content = new Drawable[]?[]
-                                                {
-                                                    [
-                                                        new MatchmakingScreenStack()
-                                                    ],
-                                                    null,
-                                                    [
-                                                        new StageDisplay
-                                                        {
-                                                            RelativeSizeAxes = Axes.X
-                                                        }
-                                                    ]
-                                                }
-                                            }
+                                            new MatchmakingScreenStack(),
                                         }
                                     }
                                 ],

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingScreenStack.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingScreenStack.cs
@@ -4,6 +4,8 @@
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
@@ -13,21 +15,59 @@ using osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
 {
-    public partial class MatchmakingScreenStack : ScreenStack
+    public partial class MatchmakingScreenStack : CompositeDrawable
     {
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
 
-        public MatchmakingScreenStack()
+        private ScreenStack screenStack = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
         {
-            Masking = true;
+            RelativeSizeAxes = Axes.Both;
+            Padding = new MarginPadding(10);
+
+            InternalChild = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                RowDimensions = new[] { new Dimension(), new Dimension(GridSizeMode.AutoSize) },
+                Content = new Drawable[][]
+                {
+                    [
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            ColumnDimensions = new[] { new Dimension(), new Dimension(GridSizeMode.Absolute, 20), new Dimension(GridSizeMode.AutoSize)},
+                            Content = new Drawable?[][]
+                            {
+                                [
+                                    screenStack = new ScreenStack(),
+                                    null,
+                                    new PlayerPanelList
+                                    {
+                                        RelativeSizeAxes = Axes.Y,
+                                        Width = 200,
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    [
+                        new StageDisplay
+                        {
+                            RelativeSizeAxes = Axes.X
+                        }
+                    ]
+                }
+            };
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            Push(new IdleScreen());
+            screenStack.Push(new IdleScreen());
 
             client.MatchRoomStateChanged += onMatchRoomStateChanged;
             onMatchRoomStateChanged(client.Room!.MatchState);
@@ -43,21 +83,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
                 case MatchmakingRoomStatus.RoomStart:
                 case MatchmakingRoomStatus.RoundStart:
                 case MatchmakingRoomStatus.RoundEnd:
-                    while (CurrentScreen is not IdleScreen)
-                        Exit();
+                    while (screenStack.CurrentScreen is not IdleScreen)
+                        screenStack.Exit();
                     break;
 
                 case MatchmakingRoomStatus.UserPicks:
-                    Push(new PickScreen());
+                    screenStack.Push(new PickScreen());
                     break;
 
                 case MatchmakingRoomStatus.SelectBeatmap:
-                    Debug.Assert(CurrentScreen is PickScreen);
-                    ((PickScreen)CurrentScreen).RollFinalBeatmap(matchmakingState.CandidateItems, matchmakingState.CandidateItem);
+                    Debug.Assert(screenStack.CurrentScreen is PickScreen);
+                    ((PickScreen)screenStack.CurrentScreen).RollFinalBeatmap(matchmakingState.CandidateItems, matchmakingState.CandidateItem);
                     break;
 
                 case MatchmakingRoomStatus.RoomEnd:
-                    Push(new ResultsScreen());
+                    screenStack.Push(new ResultsScreen());
                     break;
             }
         });

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingScreenStack.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingScreenStack.cs
@@ -39,6 +39,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
                         {
                             RelativeSizeAxes = Axes.Both,
                             ColumnDimensions = new[] { new Dimension(), new Dimension(GridSizeMode.Absolute, 20), new Dimension(GridSizeMode.AutoSize)},
+                            Padding = new MarginPadding { Bottom = 20 },
                             Content = new Drawable?[][]
                             {
                                 [


### PR DESCRIPTION
Moves the responsibility for the main matchmaking layout into the `MatchmakingScreenStack` and adds a participant list to all screens. Planning to do the handling for the participant list w/ respect to the current subscreen as a follow-up to keep this change simple.

<img width="1060" height="859" alt="image" src="https://github.com/user-attachments/assets/b8e1e86a-7a0f-4e87-b2e8-1197630d43d2" />

