### PR TITLE
Add exit confirmation to matchmaking screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
@@ -23,6 +23,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.OnlinePlay.Match.Components;
@@ -63,6 +64,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         [Resolved]
         private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
+
+        [Resolved]
+        private IDialogOverlay dialogOverlay { get; set; } = null!;
 
         private readonly MultiplayerRoom room;
 
@@ -278,13 +282,32 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
                 }));
         }
 
+        private bool exitConfirmed;
+
         public override bool OnExiting(ScreenExitEvent e)
         {
             if (base.OnExiting(e))
                 return true;
 
-            client.LeaveRoom().FireAndForget();
-            return false;
+            if (exitConfirmed)
+            {
+                client.LeaveRoom().FireAndForget();
+                return false;
+            }
+
+            if (dialogOverlay.CurrentDialog is ConfirmDialog confirmDialog)
+                confirmDialog.PerformOkAction();
+            else
+            {
+                dialogOverlay.Push(new ConfirmDialog("Are you sure you want to leave this multiplayer match?", () =>
+                {
+                    exitConfirmed = true;
+                    if (this.IsCurrentScreen())
+                        this.Exit();
+                }));
+            }
+
+            return true;
         }
 
         public override void OnResuming(ScreenTransitionEvent e)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingQueueScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingQueueScreen.cs
@@ -21,7 +21,7 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
-using osu.Game.Screens.Menu;
+using osu.Game.Overlays.Dialog;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
@@ -176,14 +176,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
             if (currentState.Value == MatchmakingScreenState.Idle)
                 return false;
 
-            dialogOverlay.Push(new ConfirmDiscardChangesDialog(() =>
+            if (dialogOverlay.CurrentDialog is ConfirmDialog confirmDialog)
+                confirmDialog.PerformOkAction();
+            else
             {
-                if (!this.IsCurrentScreen())
-                    this.MakeCurrent();
-
-                exitConfirmed = true;
-                this.Exit();
-            }));
+                dialogOverlay.Push(new ConfirmDialog("Are you sure you want to leave the matchmaking queue?", () =>
+                {
+                    exitConfirmed = true;
+                    if (this.IsCurrentScreen())
+                        this.Exit();
+                }));
+            }
 
             return true;
         }


### PR DESCRIPTION
Both implementations copied from `MatchmakingMatchSubScreen` (queue screen was using wrong dialog).