### PR TITLE
Fix results screen crash from missing users

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneRoomStatisticPanel.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneRoomStatisticPanel.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics;
-using osu.Game.Online.API.Requests.Responses;
-using osu.Game.Online.Multiplayer;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results;
 using osu.Game.Tests.Visual.Multiplayer;
 
@@ -15,14 +13,7 @@ namespace osu.Game.Tests.Visual.Matchmaking
         {
             base.SetUpSteps();
 
-            AddStep("add statistic", () => Child = new RoomStatisticPanel("Statistic description", new MultiplayerRoomUser(1)
-            {
-                User = new APIUser
-                {
-                    Id = 1,
-                    Username = "peppy"
-                }
-            })
+            AddStep("add statistic", () => Child = new RoomStatisticPanel("Statistic description", 1)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Results/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Results/ResultsScreen.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -321,12 +320,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results
 
             void addStatistic(int userId, string text)
             {
-                MultiplayerRoomUser? user = client.Room?.Users.FirstOrDefault(u => u.UserID == userId);
-
-                if (user == null)
-                    throw new InvalidOperationException($"User not found in room: {userId}");
-
-                roomStatistics.Add(new RoomStatisticPanel(text, user)
+                roomStatistics.Add(new RoomStatisticPanel(text, userId)
                 {
                     Anchor = Anchor.TopCentre,
                     Origin = Anchor.TopCentre

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Results/RoomStatisticPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/Results/RoomStatisticPanel.cs
@@ -2,11 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Game.Database;
 using osu.Game.Graphics.Sprites;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.API.Requests.Responses;
 using osuTK.Graphics;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results
@@ -16,19 +18,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results
         private readonly Color4 backgroundColour = Color4.SaddleBrown;
 
         private readonly string text;
-        private readonly MultiplayerRoomUser user;
+        private readonly int userId;
 
-        public RoomStatisticPanel(string text, MultiplayerRoomUser user)
+        public RoomStatisticPanel(string text, int userId)
         {
             this.text = text;
-            this.user = user;
+            this.userId = userId;
 
             AutoSizeAxes = Axes.Both;
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(UserLookupCache userLookupCache)
         {
+            // Should be cached by this point.
+            APIUser? user = userLookupCache.GetUserAsync(userId).GetResultSafely();
+
             InternalChild = new CircularContainer
             {
                 AutoSizeAxes = Axes.Both,
@@ -43,7 +48,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens.Results
                     new OsuSpriteText
                     {
                         Margin = new MarginPadding(10),
-                        Text = $"{text}: {user.User?.Username}"
+                        Text = $"{text}: {user?.Username}"
                     }
                 }
             };


### PR DESCRIPTION
Since `client.Room.Users` is not an immutable list and represents the participants currently in the room, users can leave the room in the transition between ResultsDisplaying -> Ended and trigger the null check.

This is somewhat of a hacky fix because I expect this to get redesigned at some point.