### PR TITLE
Pessimistically set the beatmap in all stages

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/MatchmakingScreen.cs
@@ -20,7 +20,6 @@ using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Online;
 using osu.Game.Online.Multiplayer;
-using osu.Game.Online.Multiplayer.MatchTypes.Matchmaking;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
@@ -217,12 +216,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking
 
         private void updateGameplayState()
         {
-            if (client.Room?.MatchState is not MatchmakingRoomState matchmakingState)
-                return;
-
-            if (matchmakingState.Stage != MatchmakingStage.WaitingForClientsBeatmapDownload)
-                return;
-
             MultiplayerPlaylistItem item = client.Room!.CurrentPlaylistItem;
             RulesetInfo ruleset = rulesets.GetRuleset(item.RulesetID)!;
             Ruleset rulesetInstance = ruleset.CreateInstance();


### PR DESCRIPTION
Something that could happen (in sequence):
- Client receives new room settings (containing the new playlist item).
- Client attempts to update the beatmap, but fails the stage check.
- Client then receives `WaitingForClientsBeatmapDownload` stage.
- There's no update of the beatmap. Hence the beatmap never gets updated/set.

In order to not deal with this, it's simpler to just always update the beatmap no matter what stage we're in.