### PR TITLE
Allow exit during matchmaking intro

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingIntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingIntroScreen.cs
@@ -40,8 +40,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
         [Resolved]
         private MatchmakingController controller { get; set; } = null!;
 
-        public override bool AllowUserExit => !ValidForResume;
-
         private Sample? dateWindupSample;
         private Sample? dateImpactSample;
         private Sample? beatmapWindupSample;
@@ -55,6 +53,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
         private IDisposable? duckOperation;
 
         protected override BackgroundScreen CreateBackground() => new MatchmakingIntroBackgroundScreen(colourProvider);
+
+        public MatchmakingIntroScreen()
+        {
+            ValidForResume = false;
+        }
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
@@ -123,14 +126,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
 
             updateAnimationState();
             playDateWindupSample();
-
-            controller.SearchInForeground();
         }
 
         public override void OnSuspending(ScreenTransitionEvent e)
         {
-            ValidForResume = false;
-
             duckOperation?.Dispose();
 
             this.FadeOut(800, Easing.OutQuint);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingIntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingIntroScreen.cs
@@ -37,9 +37,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
         [Resolved]
         private MusicController musicController { get; set; } = null!;
 
-        [Resolved]
-        private MatchmakingController controller { get; set; } = null!;
-
         private Sample? dateWindupSample;
         private Sample? dateImpactSample;
         private Sample? beatmapWindupSample;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingQueueScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Screens/MatchmakingQueueScreen.cs
@@ -169,6 +169,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Screens
         {
             base.OnEntering(e);
 
+            controller.SearchInForeground();
+
             client.MatchmakingJoinLobby().FireAndForget();
 
             using (BeginDelayedSequence(800))


### PR DESCRIPTION
Not sure why this was made so complex. As long as the queue screen handles the foregrounding/backgrounding, the intro screen doesn't seem to need to be involved at all.

Seems to work fine on a few basic tests?