### PR TITLE
Load beatmap & display RankedPlayCard in RankedPlayScreen.Card

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Facades/CardFacade.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Facades/CardFacade.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Facades
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
 
-            Size = RankedPlayScreen.Card.SIZE;
+            Size = RankedPlayCard.SIZE * 0.4f;
             Padding = new MarginPadding(-10);
 
             AddInternal(DebugOverlay = new DebugBox());

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCard.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class RankedPlayCard : CompositeDrawable
     {
+        public static readonly Vector2 SIZE = new Vector2(300, 500);
+
         private const float shiny_alpha = 0.2f;
 
         private static FontUsage heading0 => OsuFont.GetFont(size: 24, weight: FontWeight.Bold);
@@ -44,7 +46,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             this.beatmap = beatmap;
 
-            Size = new Vector2(300, 500);
+            Size = SIZE;
         }
 
         [BackgroundDependencyLoader]
@@ -221,7 +223,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                     {
                                         Anchor = Anchor.TopCentre,
                                         Origin = Anchor.TopCentre,
-                                        Text = $"User Rating {beatmap.BeatmapSet!.Ratings.Average():0.00}",
+                                        Text = beatmap.BeatmapSet!.Ratings.Length > 0
+                                            ? $"User Rating {beatmap.BeatmapSet!.Ratings.Average():0.00}"
+                                            : $"User Rating unknown",
                                         Font = OsuFont.Style.Body.With(weight: FontWeight.Bold)
                                     },
                                     new UserRatingDisplay

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCard.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCard.cs
@@ -225,7 +225,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                         Origin = Anchor.TopCentre,
                                         Text = beatmap.BeatmapSet!.Ratings.Length > 0
                                             ? $"User Rating {beatmap.BeatmapSet!.Ratings.Average():0.00}"
-                                            : $"User Rating unknown",
+                                            : "User Rating unknown",
                                         Font = OsuFont.Style.Body.With(weight: FontWeight.Bold)
                                     },
                                     new UserRatingDisplay

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCardBackSide.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayCardBackSide.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class RankedPlayCardBackSide : CompositeDrawable
+    {
+        public RankedPlayCardBackSide()
+        {
+            Size = RankedPlayCard.SIZE;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OverlayColourProvider colourProvider)
+        {
+            InternalChild = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = colourProvider.Background1,
+            };
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.Card.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.Card.cs
@@ -9,11 +9,9 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Threading;
 using osu.Game.Database;
-using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
@@ -35,8 +33,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             private readonly Bindable<MultiplayerPlaylistItem?> playlistItem = new Bindable<MultiplayerPlaylistItem?>();
 
-            private readonly Box background;
-            private readonly OsuSpriteText beatmapIdText;
             private readonly Container shadow;
             private readonly Container content;
 
@@ -58,7 +54,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     {
                         RelativeSizeAxes = Axes.Both,
                         Masking = true,
-                        CornerRadius = 10,
+                        CornerRadius = 25,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         EdgeEffect = new EdgeEffectParameters
@@ -74,7 +70,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Masking = true,
-                        CornerRadius = 10,
+                        CornerRadius = 25,
                         BorderColour = Color4.Yellow,
                         BorderThickness = 0,
                         Child = new RankedPlayCardBackSide()
@@ -131,7 +127,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             private void onSelectedChanged(ValueChangedEvent<bool> e)
             {
-                content.BorderThickness = e.NewValue ? 5 : 0;
+                content.BorderThickness = e.NewValue ? 12.5f : 0;
             }
 
             private void onPlaylistItemChanged(ValueChangedEvent<MultiplayerPlaylistItem?> e)
@@ -197,7 +193,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Type = EdgeEffectType.Shadow,
                     Radius = 10,
                     Colour = Color4.Black.Opacity(0.1f),
-                    Offset = new Vector2(-elevation.Current, elevation.Current)
+                    Offset = new Vector2(-elevation.Current * 2.5f, elevation.Current)
                 };
             }
 


### PR DESCRIPTION
RankedPlayCard is 2.5x larger than RankedPlayScreen.Card so I had to do some corrections to the corner radius & border width as a temporary workaround. I plan to make them both the same size once I start working on the actual card designs.

Test scene should probably have cards populated but not entirely sure in what order these would be received by the client in typically.

https://github.com/user-attachments/assets/254ce30a-8a7b-4e34-9d41-56dd80879b69

