### PR TITLE
Move user states into RankedPlayRoomState

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayCornerPiece.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayCornerPiece.cs
@@ -1,44 +1,36 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
+using osu.Game.Tests.Visual.Multiplayer;
 
 namespace osu.Game.Tests.Visual.RankedPlay
 {
-    public partial class TestSceneRankedPlayCornerPiece : OsuTestScene
+    public partial class TestSceneRankedPlayCornerPiece : MultiplayerTestScene
     {
-        [BackgroundDependencyLoader]
-        private void load()
+        public override void SetUpSteps()
         {
-            Children =
+            base.SetUpSteps();
+
+            AddStep("add children", () => Children =
             [
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Blue, Anchor.BottomLeft)
                 {
-                    Child = new RankedPlayUserDisplay(new APIUser
-                    {
-                        Username = "BTMC",
-                        Id = 3171691,
-                    }, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+                    Child = new RankedPlayUserDisplay(1, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
                     {
                         RelativeSizeAxes = Axes.Both,
                     }
                 },
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Red, Anchor.TopRight)
                 {
-                    Child = new RankedPlayUserDisplay(new APIUser
-                    {
-                        Username = "Happy_24",
-                        Id = 12876323,
-                    }, Anchor.TopRight, RankedPlayColourScheme.Red)
+                    Child = new RankedPlayUserDisplay(2, Anchor.TopRight, RankedPlayColourScheme.Red)
                     {
                         RelativeSizeAxes = Axes.Both,
                     }
                 },
-            ];
+            ]);
         }
     }
 }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -52,7 +52,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
                 AddStep("add card", () => MultiplayerClient.RankedPlayAddCard(new RankedPlayCardItem()).WaitSafely());
 
             for (int i = 0; i < 3; i++)
-                AddStep("remove card", () => MultiplayerClient.RankedPlayRemoveCard(((RankedPlayUserState)MultiplayerClient.LocalUser!.MatchState!).Hand[0]).WaitSafely());
+                AddStep("remove card", () => MultiplayerClient.RankedPlayRemoveCard(hand => hand[0]).WaitSafely());
         }
 
         [Test]
@@ -63,7 +63,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
             for (int i = 0; i < 3; i++)
             {
                 int i2 = i;
-                AddStep("reveal card", () => MultiplayerClient.RankedPlayRevealCard(((RankedPlayUserState)MultiplayerClient.LocalUser!.MatchState!).Hand[i2], new MultiplayerPlaylistItem
+                AddStep("reveal card", () => MultiplayerClient.RankedPlayRevealCard(hand => hand[i2], new MultiplayerPlaylistItem
                 {
                     ID = i2,
                     BeatmapID = i2
@@ -76,7 +76,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay).WaitSafely());
             AddWaitStep("wait", 3);
-            AddStep("play card", () => MultiplayerClient.PlayCard(((RankedPlayUserState)MultiplayerClient.LocalUser!.MatchState!).Hand[0]).WaitSafely());
+            AddStep("play card", () => MultiplayerClient.PlayCard(hand => hand[0]).WaitSafely());
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("set discard phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardDiscard).WaitSafely());
             AddWaitStep("wait", 3);
-            AddStep("discard cards", () => MultiplayerClient.DiscardCards(((RankedPlayUserState)MultiplayerClient.LocalUser!.MatchState!).Hand.Take(3).ToArray()).WaitSafely());
+            AddStep("discard cards", () => MultiplayerClient.DiscardCards(hand => hand.Take(3)).WaitSafely());
             AddWaitStep("wait", 13);
             AddStep("set finish discard phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.FinishCardDiscard).WaitSafely());
         }
@@ -151,7 +151,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActivePlayerIndex = 1).WaitSafely());
             AddWaitStep("wait", 5);
-            AddStep("play beatmap", () => MultiplayerClient.PlayCard(((RankedPlayUserState)MultiplayerClient.ServerRoom!.Users[1].MatchState!).Hand[0]).WaitSafely());
+            AddStep("play beatmap", () => MultiplayerClient.PlayCard(hand => hand[0]).WaitSafely());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -151,7 +151,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         {
             AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActivePlayerIndex = 1).WaitSafely());
             AddWaitStep("wait", 5);
-            AddStep("play beatmap", () => MultiplayerClient.PlayCard(hand => hand[0]).WaitSafely());
+            AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(2, hand => hand[0]).WaitSafely());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -49,10 +49,10 @@ namespace osu.Game.Tests.Visual.RankedPlay
             AddStep("set discard phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardDiscard).WaitSafely());
 
             for (int i = 0; i < 3; i++)
-                AddStep("add card", () => MultiplayerClient.RankedPlayAddCard(new RankedPlayCardItem()).WaitSafely());
+                AddStep("add card", () => MultiplayerClient.RankedPlayAddCards([new RankedPlayCardItem()]).WaitSafely());
 
             for (int i = 0; i < 3; i++)
-                AddStep("remove card", () => MultiplayerClient.RankedPlayRemoveCard(hand => hand[0]).WaitSafely());
+                AddStep("remove card", () => MultiplayerClient.RankedPlayRemoveCards(hand => [hand[0]]).WaitSafely());
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -149,7 +149,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TestOtherPlaysCard()
         {
-            AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActivePlayerIndex = 1).WaitSafely());
+            AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = 2).WaitSafely());
             AddWaitStep("wait", 5);
             AddStep("play beatmap", () => MultiplayerClient.PlayUserCard(2, hand => hand[0]).WaitSafely());
         }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -123,7 +123,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TestPlayStage()
         {
-            AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay).WaitSafely());
+            AddStep("set play phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = API.LocalUser.Value.OnlineID).WaitSafely());
 
             for (int i = 0; i < 3; i++)
             {

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
@@ -2,44 +2,57 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
-using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
+using osu.Game.Tests.Visual.Multiplayer;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.RankedPlay
 {
-    public partial class TestSceneRankedPlayUserDisplay : OsuTestScene
+    public partial class TestSceneRankedPlayUserDisplay : MultiplayerTestScene
     {
-        private RankedPlayUserDisplay userDisplay;
-
-        public TestSceneRankedPlayUserDisplay()
+        private readonly BindableInt health = new BindableInt
         {
-            Child = userDisplay = new RankedPlayUserDisplay(new APIUser(), Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+            MaxValue = 1_000_000,
+            MinValue = 0,
+            Value = 1_000_000,
+        };
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("add display", () => Child = new RankedPlayUserDisplay(1, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(256, 72)
-            };
+                Size = new Vector2(256, 72),
+                Health = { BindTarget = health }
+            });
         }
 
         [Test]
         public void TesUserDisplay()
         {
-            AddStep("blue color scheme", () => Child = userDisplay = new RankedPlayUserDisplay(new APIUser(), Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+            AddStep("blue color scheme", () => Child = new RankedPlayUserDisplay(1, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(256, 72)
+                Size = new Vector2(256, 72),
+                Health = { BindTarget = health }
             });
-            AddStep("red color scheme", () => Child = userDisplay = new RankedPlayUserDisplay(new APIUser(), Anchor.BottomLeft, RankedPlayColourScheme.Red)
+
+            AddStep("red color scheme", () => Child = new RankedPlayUserDisplay(1, Anchor.BottomLeft, RankedPlayColourScheme.Red)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(256, 72)
+                Size = new Vector2(256, 72),
+                Health = { BindTarget = health }
             });
-            AddSliderStep("health", 0, 1_000_000, 1_000_000, value => userDisplay.Health.Value = value);
+
+            AddSliderStep("health", 0, 1_000_000, 1_000_000, value => health.Value = value);
         }
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
@@ -33,5 +34,8 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// </summary>
         [Key(3)]
         public int ActivePlayerIndex { get; set; }
+
+        [Key(4)]
+        public Dictionary<int, RankedPlayUserInfo> Users { get; set; } = [];
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
@@ -30,12 +30,21 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         public double DamageMultiplier { get; set; }
 
         /// <summary>
-        /// The index of the user currently playing a card.
+        /// A dictionary containing all users in the room.
         /// </summary>
         [Key(3)]
-        public int ActivePlayerIndex { get; set; }
-
-        [Key(4)]
         public Dictionary<int, RankedPlayUserInfo> Users { get; set; } = [];
+
+        /// <summary>
+        /// The ID of the user currently playing a card.
+        /// </summary>
+        [Key(4)]
+        public int ActiveUserId { get; set; }
+
+        /// <summary>
+        /// The user currently playing a card.
+        /// </summary>
+        [IgnoreMember]
+        public RankedPlayUserInfo ActiveUser => Users[ActiveUserId];
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
@@ -2,13 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using MessagePack;
 
 namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
 {
     [Serializable]
     [MessagePackObject]
-    public class RankedPlayUserState : MatchUserState
+    public class RankedPlayUserInfo
     {
         /// <summary>
         /// The current life points.
@@ -20,6 +21,6 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// The cards in this user's hand.
         /// </summary>
         [Key(1)]
-        public RankedPlayCardItem[] Hand { get; set; } = [];
+        public List<RankedPlayCardItem> Hand { get; set; } = [];
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchUserState.cs
+++ b/osu.Game/Online/Multiplayer/MatchUserState.cs
@@ -3,7 +3,6 @@
 
 using System;
 using MessagePack;
-using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Multiplayer.MatchTypes.TeamVersus;
 
 namespace osu.Game.Online.Multiplayer
@@ -15,7 +14,6 @@ namespace osu.Game.Online.Multiplayer
     [Serializable]
     [MessagePackObject]
     [Union(0, typeof(TeamVersusUserState))] // IMPORTANT: Add rules to SignalRUnionWorkaroundResolver for new derived types.
-    [Union(2, typeof(RankedPlayUserState))]
     public abstract class MatchUserState
     {
     }

--- a/osu.Game/Online/SignalRWorkaroundTypes.cs
+++ b/osu.Game/Online/SignalRWorkaroundTypes.cs
@@ -62,7 +62,6 @@ namespace osu.Game.Online
 
             // ranked play
             (typeof(RankedPlayRoomState), typeof(MatchRoomState)),
-            (typeof(RankedPlayUserState), typeof(MatchUserState)),
             (typeof(RankedPlayStageCountdown), typeof(MultiplayerCountdown)),
         };
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -12,6 +13,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Utils;
+using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Backgrounds;
 using osu.Game.Graphics.Sprites;
@@ -26,8 +28,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
     public partial class RankedPlayUserDisplay : CompositeDrawable
     {
-        private readonly APIUser user;
-
         public readonly BindableInt Health = new BindableInt
         {
             MaxValue = 1_000_000,
@@ -35,9 +35,27 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             Value = 1_000_000,
         };
 
-        public RankedPlayUserDisplay(APIUser user, Anchor contentAnchor, RankedPlayColourScheme colourScheme)
+        [Resolved]
+        private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private UserLookupCache users { get; set; } = null!;
+
+        private readonly int userId;
+        private readonly Anchor contentAnchor;
+        private readonly RankedPlayColourScheme colourScheme;
+
+        public RankedPlayUserDisplay(int userId, Anchor contentAnchor, RankedPlayColourScheme colourScheme)
         {
-            this.user = user;
+            this.userId = userId;
+            this.contentAnchor = contentAnchor;
+            this.colourScheme = colourScheme;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            APIUser user = users.GetUserAsync(userId).GetResultSafely()!;
 
             InternalChildren =
             [
@@ -92,29 +110,24 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             ];
         }
 
-        [Resolved]
-        private MultiplayerClient client { get; set; } = null!;
-
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            client.RoomUpdated += onRoomUpdated;
+            client.MatchRoomStateChanged += onRoomStateChanged;
         }
 
-        private void onRoomUpdated()
+        private void onRoomStateChanged(MatchRoomState state) => Scheduler.Add(() =>
         {
-            var roomState = (RankedPlayRoomState?)client.Room?.MatchState;
-
-            if (roomState == null)
+            if (state is not RankedPlayRoomState rankedPlayState)
                 return;
 
-            Health.Value = roomState.Users[user.Id].Life;
-        }
+            Health.Value = rankedPlayState.Users[userId].Life;
+        });
 
         protected override void Dispose(bool isDisposing)
         {
-            client.RoomUpdated -= onRoomUpdated;
+            client.MatchRoomStateChanged -= onRoomStateChanged;
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
@@ -105,10 +104,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         private void onRoomUpdated()
         {
-            if (client.Room?.Users.FirstOrDefault(it => it.UserID == user.Id)?.MatchState is not RankedPlayUserState matchState)
+            var roomState = (RankedPlayRoomState?)client.Room?.MatchState;
+
+            if (roomState == null)
                 return;
 
-            Health.Value = matchState.Life;
+            Health.Value = roomState.Users[user.Id].Life;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -292,8 +292,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     break;
 
                 case RankedPlayStage.CardPlay:
-                    bool isActivePlayer = client.Room!.Users[rankedPlayState.ActivePlayerIndex].Equals(client.LocalUser);
-
+                    bool isActivePlayer = rankedPlayState.ActiveUserId == client.LocalUser?.UserID;
                     ShowScreen(isActivePlayer ? new PickScreen() : new OpponentPickScreen());
                     break;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -139,13 +139,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             beatmapAvailabilityTracker.Availability.BindValueChanged(onBeatmapAvailabilityChanged, true);
 
-            foreach (var user in client.Room!.Users)
+            var roomState = (RankedPlayRoomState)client.Room!.MatchState!;
+
+            foreach ((int userId, RankedPlayUserInfo userInfo) in roomState.Users)
             {
-                var cardOwner = getCardOwner(user.UserID);
+                var cardOwner = getCardOwner(userId);
 
-                var localUserState = (RankedPlayUserState)user.MatchState!;
-
-                foreach (var item in localUserState.Hand)
+                foreach (var item in userInfo.Hand)
                 {
                     var facade = cardOwner == CardOwner.Player ? hiddenPlayerCardFacade : hiddenOpponentCardFacade;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -19,6 +19,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Online;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
@@ -46,6 +47,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
         private BeatmapManager beatmapManager { get; set; } = null!;
@@ -167,20 +171,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 opponentCards.Remove(card);
             };
 
-            var ownUser = client.LocalUser!.User!;
-            var opponent = client.Room!.Users.First(it => it.UserID != ownUser.Id).User!;
+            int localUserId = api.LocalUser.Value.OnlineID;
+            int opponentUserId = ((RankedPlayRoomState)client.Room.MatchState!).Users.Keys.Single(it => it != localUserId);
 
             AddRangeInternal([
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Blue, Anchor.BottomLeft)
                 {
-                    Child = new RankedPlayUserDisplay(client.LocalUser!.User!, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
+                    Child = new RankedPlayUserDisplay(localUserId, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
                     {
                         RelativeSizeAxes = Axes.Both,
                     }
                 },
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Red, Anchor.TopRight)
                 {
-                    Child = new RankedPlayUserDisplay(opponent, Anchor.TopRight, RankedPlayColourScheme.Red)
+                    Child = new RankedPlayUserDisplay(opponentUserId, Anchor.TopRight, RankedPlayColourScheme.Red)
                     {
                         RelativeSizeAxes = Axes.Both,
                     }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -941,7 +941,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 await ((IRankedPlayClient)this).RankedPlayCardAdded(userId, clone(card)).ConfigureAwait(false);
             }
 
-            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState));
+            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -963,7 +963,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 await ((IRankedPlayClient)this).RankedPlayCardRemoved(userId, clone(card)).ConfigureAwait(false);
             }
 
-            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState));
+            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState)).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -822,13 +822,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         public async Task DiscardUserCards(int userId, Func<RankedPlayCardItem[], IEnumerable<RankedPlayCardItem>> selector)
         {
-            RankedPlayCardItem[] discarded = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray()).ToArray();
+            RankedPlayUserInfo info = ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId];
+            RankedPlayCardItem[] cards = selector(info.Hand.ToArray()).ToArray();
 
-            foreach (var card in discarded)
-                await RankedPlayRemoveUserCard(userId, _ => card).ConfigureAwait(false);
-
-            foreach (var _ in discarded)
-                await RankedPlayAddCard(clone(new RankedPlayCardItem())).ConfigureAwait(false);
+            await RankedPlayRemoveUserCards(userId, _ => cards).ConfigureAwait(false);
+            await RankedPlayAddUserCards(userId, Enumerable.Range(0, cards.Length).Select(_ => new RankedPlayCardItem()).ToArray()).ConfigureAwait(false);
         }
 
         public override Task PlayCard(RankedPlayCardItem card)
@@ -929,34 +927,43 @@ namespace osu.Game.Tests.Visual.Multiplayer
         /// <summary>
         /// Adds a card to the local user's hand.
         /// </summary>
-        public Task RankedPlayAddCard(RankedPlayCardItem card)
-            => RankedPlayAddUserCard(api.LocalUser.Value.OnlineID, card);
+        public Task RankedPlayAddCards(RankedPlayCardItem[] cards)
+            => RankedPlayAddUserCards(api.LocalUser.Value.OnlineID, cards);
 
         /// <summary>
         /// Adds a card to the given user's hand.
         /// </summary>
-        public async Task RankedPlayAddUserCard(int userId, RankedPlayCardItem card)
+        public async Task RankedPlayAddUserCards(int userId, RankedPlayCardItem[] cards)
         {
-            ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.Add(card);
+            foreach (var card in cards)
+            {
+                ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.Add(card);
+                await ((IRankedPlayClient)this).RankedPlayCardAdded(userId, clone(card)).ConfigureAwait(false);
+            }
+
             await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState));
-            await ((IRankedPlayClient)this).RankedPlayCardAdded(userId, clone(card)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Removes a card from the local user's hand.
         /// </summary>
-        public Task RankedPlayRemoveCard(Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
-            => RankedPlayRemoveUserCard(api.LocalUser.Value.OnlineID, selector);
+        public Task RankedPlayRemoveCards(Func<RankedPlayCardItem[], RankedPlayCardItem[]> selector)
+            => RankedPlayRemoveUserCards(api.LocalUser.Value.OnlineID, selector);
 
         /// <summary>
         /// Removes a card from the given user's hand.
         /// </summary>
-        public async Task RankedPlayRemoveUserCard(int userId, Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
+        public async Task RankedPlayRemoveUserCards(int userId, Func<RankedPlayCardItem[], RankedPlayCardItem[]> selector)
         {
-            RankedPlayCardItem card = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray());
-            ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.Remove(card);
+            RankedPlayCardItem[] cards = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray());
+
+            foreach (var card in cards)
+            {
+                ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.Remove(card);
+                await ((IRankedPlayClient)this).RankedPlayCardRemoved(userId, clone(card)).ConfigureAwait(false);
+            }
+
             await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState));
-            await ((IRankedPlayClient)this).RankedPlayCardRemoved(userId, clone(card)).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -127,8 +127,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     break;
 
                 case RankedPlayRoomState:
-                    user.MatchState = new RankedPlayUserState { Hand = Enumerable.Range(0, 5).Select(_ => new RankedPlayCardItem()).ToArray() };
-                    ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(user.MatchState)).WaitSafely();
+                    ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[user.UserID] = new RankedPlayUserInfo
+                    {
+                        Hand = Enumerable.Range(0, 5).Select(_ => new RankedPlayCardItem()).ToList()
+                    };
+
+                    ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).WaitSafely();
                     break;
             }
         }
@@ -635,11 +639,20 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
                 case MatchType.RankedPlay:
                     ServerRoom.MatchState = new RankedPlayRoomState();
+
+                    foreach (var user in ServerRoom.Users)
+                    {
+                        ((RankedPlayRoomState)ServerRoom.MatchState).Users[user.UserID] = new RankedPlayUserInfo
+                        {
+                            Hand = Enumerable.Range(0, 5).Select(_ => new RankedPlayCardItem()).ToList()
+                        };
+                    }
+
                     await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
 
                     foreach (var user in ServerRoom.Users)
                     {
-                        user.MatchState = new RankedPlayUserState { Hand = Enumerable.Range(0, 5).Select(_ => new RankedPlayCardItem()).ToArray() };
+                        user.MatchState = null;
                         await ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(user.MatchState)).ConfigureAwait(false);
                     }
 
@@ -801,17 +814,32 @@ namespace osu.Game.Tests.Visual.Multiplayer
             await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom.MatchState)).ConfigureAwait(false);
         }
 
-        public override async Task DiscardCards(RankedPlayCardItem[] cards)
-        {
-            foreach (var card in cards)
-                await RankedPlayRemoveCard(card).ConfigureAwait(false);
+        public override Task DiscardCards(RankedPlayCardItem[] cards)
+            => DiscardCards(_ => cards);
 
-            foreach (var _ in cards)
-                await RankedPlayAddCard(new RankedPlayCardItem()).ConfigureAwait(false);
+        public Task DiscardCards(Func<RankedPlayCardItem[], IEnumerable<RankedPlayCardItem>> selector)
+            => DiscardUserCards(api.LocalUser.Value.OnlineID, selector);
+
+        public async Task DiscardUserCards(int userId, Func<RankedPlayCardItem[], IEnumerable<RankedPlayCardItem>> selector)
+        {
+            RankedPlayCardItem[] discarded = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray()).ToArray();
+
+            foreach (var card in discarded)
+                await RankedPlayRemoveUserCard(userId, _ => card).ConfigureAwait(false);
+
+            foreach (var _ in discarded)
+                await RankedPlayAddCard(clone(new RankedPlayCardItem())).ConfigureAwait(false);
         }
 
-        public override async Task PlayCard(RankedPlayCardItem card)
+        public override Task PlayCard(RankedPlayCardItem card)
+            => PlayCard(_ => card);
+
+        public Task PlayCard(Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
+            => PlayUserCard(api.LocalUser.Value.OnlineID, selector);
+
+        public async Task PlayUserCard(int userId, Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
         {
+            RankedPlayCardItem card = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray());
             await ((IRankedPlayClient)this).RankedPlayCardPlayed(clone(card)).ConfigureAwait(false);
         }
 
@@ -899,44 +927,50 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         /// <summary>
-        /// Adds a card for the local user.
+        /// Adds a card to the local user's hand.
         /// </summary>
         public Task RankedPlayAddCard(RankedPlayCardItem card)
             => RankedPlayAddUserCard(api.LocalUser.Value.OnlineID, card);
 
         /// <summary>
-        /// Adds a card for the given user.
+        /// Adds a card to the given user's hand.
         /// </summary>
         public async Task RankedPlayAddUserCard(int userId, RankedPlayCardItem card)
         {
-            var userState = (RankedPlayUserState)ServerRoom!.Users.Single(u => u.UserID == userId).MatchState!;
-            userState.Hand = userState.Hand.Concat([card]).ToArray();
-            await ((IMultiplayerClient)this).MatchUserStateChanged(userId, clone(userState)).ConfigureAwait(false);
+            ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.Add(card);
+            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState));
             await ((IRankedPlayClient)this).RankedPlayCardAdded(userId, clone(card)).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Removes a card from the local user.
+        /// Removes a card from the local user's hand.
         /// </summary>
-        public Task RankedPlayRemoveCard(RankedPlayCardItem card)
-            => RankedPlayRemoveUserCard(api.LocalUser.Value.OnlineID, card);
+        public Task RankedPlayRemoveCard(Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
+            => RankedPlayRemoveUserCard(api.LocalUser.Value.OnlineID, selector);
 
         /// <summary>
-        /// Removes a card for the given user.
+        /// Removes a card from the given user's hand.
         /// </summary>
-        public async Task RankedPlayRemoveUserCard(int userId, RankedPlayCardItem card)
+        public async Task RankedPlayRemoveUserCard(int userId, Func<RankedPlayCardItem[], RankedPlayCardItem> selector)
         {
-            var userState = (RankedPlayUserState)ServerRoom!.Users.Single(u => u.UserID == userId).MatchState!;
-            userState.Hand = userState.Hand.Except([card]).ToArray();
-            await ((IMultiplayerClient)this).MatchUserStateChanged(userId, clone(userState)).ConfigureAwait(false);
+            RankedPlayCardItem card = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray());
+            ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.Remove(card);
+            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState));
             await ((IRankedPlayClient)this).RankedPlayCardRemoved(userId, clone(card)).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Reveals a card.
+        /// Reveals a card in the local user's hand.
         /// </summary>
-        public async Task RankedPlayRevealCard(RankedPlayCardItem card, MultiplayerPlaylistItem item)
+        public Task RankedPlayRevealCard(Func<RankedPlayCardItem[], RankedPlayCardItem> selector, MultiplayerPlaylistItem item)
+            => RankedPlayRevealUserCard(api.LocalUser.Value.OnlineID, selector, item);
+
+        /// <summary>
+        /// Reveals a card in the given user's hand.
+        /// </summary>
+        public async Task RankedPlayRevealUserCard(int userId, Func<RankedPlayCardItem[], RankedPlayCardItem> selector, MultiplayerPlaylistItem item)
         {
+            RankedPlayCardItem card = selector(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId].Hand.ToArray());
             await ((IRankedPlayClient)this).RankedPlayCardRevealed(clone(card), clone(item)).ConfigureAwait(false);
         }
 
@@ -959,19 +993,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
             }).ConfigureAwait(false);
         }
 
-        public async Task RankedPlayChangeUserState(int userId, Action<RankedPlayUserState> prepare)
+        public async Task RankedPlayChangeUserState(int userId, Action<RankedPlayUserInfo> prepare)
         {
             Debug.Assert(ServerRoom != null);
 
-            var user = ServerRoom.Users.Single(u => u.UserID == userId);
+            var userInfo = clone(((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId]);
+            prepare(userInfo);
 
-            RankedPlayUserState state = clone((RankedPlayUserState)user.MatchState!);
-
-            prepare(state);
-
-            user.MatchState = state;
-
-            await ((IMultiplayerClient)this).MatchUserStateChanged(clone(user.UserID), clone(state)).ConfigureAwait(false);
+            ((RankedPlayRoomState)ServerRoom!.MatchState!).Users[userId] = userInfo;
+            await ((IMultiplayerClient)this).MatchRoomStateChanged(clone(ServerRoom!.MatchState)).ConfigureAwait(false);
         }
 
         #region API Room Handling


### PR DESCRIPTION
Because `MultiplayerRoom.Users` tracks users actively in the room (and thus users may not exist in it), this changes things to store user states as part of the room, accessible via `RankedPlayRoomState.Users`. It's similar to quick play, but simplified.

`ActivePlayerIndex` has been turned into `ActiveUserId` because the former kind of doesn't really work with this structure. I'm still not sure whether this state will remain for release - depends on if we have a use for it but primarily it's used server-side.

`RankedPlayUserDisplay` is now based on user id, so that it doesn't rely on `MultiplayerRoomUser` objects existing.