### PR TITLE
Integrate intro screen into RankedPlayScreen

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneIntroScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneIntroScreen.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Tests.Visual.Matchmaking;
 
@@ -11,6 +13,11 @@ namespace osu.Game.Tests.Visual.RankedPlay
         public override void SetUpSteps()
         {
             base.SetUpSteps();
+
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.RankedPlay)));
+            WaitForJoined();
+
+            AddStep("join other user", () => MultiplayerClient.AddUser(new APIUser { Id = 2 }));
 
             AddStep("Add screen", () => Child = new IntroScreen());
         }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayCornerPiece.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayCornerPiece.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -10,14 +13,16 @@ namespace osu.Game.Tests.Visual.RankedPlay
 {
     public partial class TestSceneRankedPlayCornerPiece : MultiplayerTestScene
     {
-        public override void SetUpSteps()
-        {
-            base.SetUpSteps();
+        private readonly Bindable<Visibility> visibility = new Bindable<Visibility>(Visibility.Visible);
 
+        [Test]
+        public void TestCornerPieces()
+        {
             AddStep("add children", () => Children =
             [
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Blue, Anchor.BottomLeft)
                 {
+                    State = { BindTarget = visibility },
                     Child = new RankedPlayUserDisplay(1, Anchor.BottomLeft, RankedPlayColourScheme.Blue)
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -25,12 +30,16 @@ namespace osu.Game.Tests.Visual.RankedPlay
                 },
                 new RankedPlayCornerPiece(RankedPlayColourScheme.Red, Anchor.TopRight)
                 {
+                    State = { BindTarget = visibility },
                     Child = new RankedPlayUserDisplay(2, Anchor.TopRight, RankedPlayColourScheme.Red)
                     {
                         RelativeSizeAxes = Axes.Both,
                     }
                 },
             ]);
+
+            AddStep("hide", () => visibility.Value = Visibility.Hidden);
+            AddStep("show", () => visibility.Value = Visibility.Visible);
         }
     }
 }

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -33,6 +33,12 @@ namespace osu.Game.Tests.Visual.RankedPlay
         }
 
         [Test]
+        public void TestIntro()
+        {
+            // nothing to do
+        }
+
+        [Test]
         public void TestAddRemoveCards()
         {
             AddStep("set discard phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardDiscard).WaitSafely());

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayScreen.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Tests.Visual.RankedPlay
         [Test]
         public void TestIntro()
         {
-            // nothing to do
+            AddStep("set round warmup phase", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.RoundWarmup).WaitSafely());
         }
 
         [Test]

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Transforms;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
@@ -109,10 +110,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         protected override void PopOut()
         {
-            this.FadeOut(300);
+            this.FadeOut(500);
 
-            background.MoveToY((Anchor & Anchor.y0) != 0 ? -120 : 120, 400, Easing.OutExpo);
-            Content.MoveToX((Anchor & Anchor.x0) != 0 ? -500 : 500, 400, Easing.OutExpo);
+            background.MoveToY((Anchor & Anchor.y0) != 0 ? -120 : 120, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
+            Content.MoveToX((Anchor & Anchor.x0) != 0 ? -500 : 500, 500, new CubicBezierEasingFunction(easeIn: 0.33, easeOut: 0.5));
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
@@ -10,8 +10,10 @@ using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 {
-    public partial class RankedPlayCornerPiece : Container
+    public partial class RankedPlayCornerPiece : VisibilityContainer
     {
+        private readonly Container background;
+
         protected override Container<Drawable> Content { get; }
 
         public RankedPlayCornerPiece(RankedPlayColourScheme colourScheme, Anchor anchor)
@@ -22,7 +24,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
             InternalChildren =
             [
-                new Container
+                background = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
                     Anchor = Anchor.Centre,
@@ -97,5 +99,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         }
 
         public static float WidthFor(float parentWidth) => float.Clamp(parentWidth * 0.25f, 250, 335);
+
+        protected override void PopIn()
+        {
+            this.FadeIn(300);
+
+            Content.MoveToX(0, 500, Easing.OutExpo);
+            background.MoveToY(0, 500, Easing.OutExpo);
+        }
+
+        protected override void PopOut()
+        {
+            this.FadeOut(300);
+
+            background.MoveToY((Anchor & Anchor.y0) != 0 ? -120 : 120, 400, Easing.OutExpo);
+            Content.MoveToX((Anchor & Anchor.x0) != 0 ? -500 : 500, 400, Easing.OutExpo);
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
@@ -84,8 +84,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 {
                     Anchor = anchor,
                     Origin = anchor,
-                    X = (anchor & Anchor.x0) != 0 ? 18 : -18,
-                    Y = (anchor & Anchor.y0) != 0 ? 18 : -18,
+                    Margin = new MarginPadding(18),
                     RelativeSizeAxes = Axes.Both,
                 }
             ];

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
@@ -14,6 +14,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
     public partial class RankedPlayCornerPiece : VisibilityContainer
     {
         private readonly Container background;
+        private readonly Container bottomLayer;
+        private readonly Container topLayer;
 
         protected override Container<Drawable> Content { get; }
 
@@ -50,11 +52,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                         },
                         Children =
                         [
-                            new Container
+                            bottomLayer = new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Masking = true,
                                 CornerRadius = 20,
+                                Anchor = Anchor.TopRight,
+                                Origin = Anchor.TopRight,
                                 Child = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
@@ -62,10 +66,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                     Alpha = 0.2f,
                                 },
                             },
-                            new Container
+                            topLayer = new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Padding = new MarginPadding(10),
+                                Anchor = Anchor.BottomLeft,
+                                Origin = Anchor.BottomLeft,
                                 Child = new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
@@ -74,7 +80,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                     Child = new Box
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        Colour = ColourInfo.GradientHorizontal(colourScheme.Primary.Opacity(0.75f), colourScheme.PrimaryDarker.Opacity(0.25f)),
+                                        Colour = ColourInfo.GradientHorizontal(colourScheme.Primary, colourScheme.PrimaryDarker.Opacity(0.35f)),
+                                        Alpha = 0.75f
                                     },
                                 },
                             }
@@ -104,16 +111,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             this.FadeIn(300);
 
-            Content.MoveToX(0, 500, Easing.OutExpo);
-            background.MoveToY(0, 500, Easing.OutExpo);
+            Content.MoveToX(0, 400, Easing.OutExpo);
+            background.MoveToY(0, 400, Easing.OutExpo);
+
+            bottomLayer.RotateTo(0, 400, Easing.OutQuart);
+            topLayer.RotateTo(0, 400, Easing.OutQuart);
         }
 
         protected override void PopOut()
         {
-            this.FadeOut(500);
+            this.FadeOut(300);
 
-            background.MoveToY((Anchor & Anchor.y0) != 0 ? -120 : 120, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
+            background.MoveToY((Anchor & Anchor.y0) != 0 ? -60 : 60, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
             Content.MoveToX((Anchor & Anchor.x0) != 0 ? -500 : 500, 500, new CubicBezierEasingFunction(easeIn: 0.33, easeOut: 0.5));
+
+            bottomLayer.RotateTo(-25, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
+            topLayer.RotateTo(25, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
@@ -88,12 +88,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                         ]
                     },
                 },
-                Content = new Container
+                new Container
                 {
+                    RelativeSizeAxes = Axes.Both,
                     Anchor = anchor,
                     Origin = anchor,
                     Margin = new MarginPadding(18),
-                    RelativeSizeAxes = Axes.Both,
+                    Child = Content = new Container
+                    {
+                        Anchor = (anchor & Anchor.x0) != 0 ? Anchor.CentreLeft : Anchor.CentreRight,
+                        Origin = (anchor & Anchor.x0) != 0 ? Anchor.CentreLeft : Anchor.CentreRight,
+                        RelativeSizeAxes = Axes.Both,
+                    }
                 }
             ];
         }
@@ -111,7 +117,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         {
             this.FadeIn(300);
 
-            Content.MoveToX(0, 400, Easing.OutExpo);
+            Content.MoveToX(0, 400, Easing.OutExpo)
+                   .ScaleTo(1f, 400, Easing.OutExpo)
+                   .FadeIn();
             background.MoveToY(0, 400, Easing.OutExpo);
 
             bottomLayer.RotateTo(0, 400, Easing.OutQuart);
@@ -123,7 +131,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             this.FadeOut(300);
 
             background.MoveToY((Anchor & Anchor.y0) != 0 ? -60 : 60, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
-            Content.MoveToX((Anchor & Anchor.x0) != 0 ? -500 : 500, 500, new CubicBezierEasingFunction(easeIn: 0.33, easeOut: 0.5));
+            Content.MoveToX((Anchor & Anchor.x0) != 0 ? -200 : 200, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.5))
+                   .ScaleTo(0.5f, 400, Easing.OutCubic)
+                   .FadeOut(200);
 
             bottomLayer.RotateTo(-25, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));
             topLayer.RotateTo(25, 500, new CubicBezierEasingFunction(easeIn: 0.2, easeOut: 0.75));

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/IntroScreen.cs
@@ -16,6 +16,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class IntroScreen : RankedPlaySubScreen
     {
+        public IntroScreen()
+        {
+            CornerPieceVisibility.Value = Visibility.Hidden;
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -88,6 +93,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 user2.MoveToY(-1, 600, Easing.InCubic);
                 box.Delay(100).ResizeHeightTo(0, 400, Easing.InQuad);
             }, 2000);
+
+            Scheduler.AddDelayed(() =>
+            {
+                CornerPieceVisibility.Value = Visibility.Visible;
+            }, 2600);
 
             Scheduler.AddDelayed(rangeDisplay.PlayAnimation, 2700);
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/IntroScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,8 +22,29 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             CornerPieceVisibility.Value = Visibility.Hidden;
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            waitForUsers();
+        }
+
+        private void waitForUsers()
+        {
+            var player = Client.LocalUser?.User;
+
+            var opponent = Client.Room?.Users.FirstOrDefault(it => it.UserID != player?.Id)?.User;
+
+            if (player == null || opponent == null)
+            {
+                Schedule(waitForUsers);
+                return;
+            }
+
+            playIntroSequence(player, opponent);
+        }
+
+        private void playIntroSequence(APIUser player, APIUser opponent)
         {
             Box box;
             Drawable user1, user2;
@@ -46,11 +68,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
-                        user1 = new CurrentlyOnlineDisplay.OnlineUserPanel(new APIUser
-                        {
-                            Id = 0,
-                            Username = "Hydrogen Bomb",
-                        })
+                        user1 = new CurrentlyOnlineDisplay.OnlineUserPanel(player)
                         {
                             RelativePositionAxes = Axes.Both,
                             Anchor = Anchor.Centre,
@@ -58,11 +76,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                             Position = new Vector2(-0.25f, -0.75f),
                             Shear = -OsuGame.SHEAR,
                         },
-                        user2 = new CurrentlyOnlineDisplay.OnlineUserPanel(new APIUser
-                        {
-                            Id = 1,
-                            Username = "Coughing Baby",
-                        })
+                        user2 = new CurrentlyOnlineDisplay.OnlineUserPanel(opponent)
                         {
                             RelativePositionAxes = Axes.Both,
                             Anchor = Anchor.Centre,

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayMatchInfo.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayMatchInfo.cs
@@ -54,7 +54,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         /// </summary>
         public event Action<RankedPlayCardWithPlaylistItem>? CardPlayed;
 
-        public bool IsOwnTurn => (client.Room?.MatchState as RankedPlayRoomState)?.ActiveUserId == client.LocalUser?.UserID;
+        public RankedPlayRoomState RoomState { get; private set; } = null!;
+
+        public bool IsOwnTurn => RoomState.ActiveUserId == client.LocalUser?.UserID;
+
+        public int CurrentRound => RoomState.CurrentRound;
 
         private readonly List<RankedPlayCardWithPlaylistItem> playerCards = new List<RankedPlayCardWithPlaylistItem>();
         private readonly List<RankedPlayCardWithPlaylistItem> opponentCards = new List<RankedPlayCardWithPlaylistItem>();
@@ -93,6 +97,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             if (state is not RankedPlayRoomState roomState)
                 return;
+
+            RoomState = roomState;
 
             stage.Value = roomState.Stage;
         }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
@@ -145,8 +146,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 },
             ]);
 
-            ShowScreen(new IntroScreen());
-
             stage.BindValueChanged(e => onStageChanged(e.NewValue));
         }
 
@@ -216,6 +215,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         {
             switch (stage)
             {
+                case RankedPlayStage.RoundWarmup when matchInfo.CurrentRound == 1:
+                    ShowScreen(new IntroScreen());
+                    break;
+
                 case RankedPlayStage.CardDiscard:
                     ShowScreen(new DiscardScreen());
                     break;
@@ -226,6 +229,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
                 case RankedPlayStage.CardPlay:
                     ShowScreen(matchInfo.IsOwnTurn ? new PickScreen() : new OpponentPickScreen());
+                    break;
+
+                case RankedPlayStage.FinishCardPlay:
+                    Debug.Assert(activeSubscreen is PickScreen || activeSubscreen is OpponentPickScreen);
                     break;
 
                 default:

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using Humanizer;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Online.Multiplayer;
@@ -15,6 +16,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
     public abstract partial class RankedPlaySubScreen : Container
     {
         public const float CENTERED_CARD_SCALE = 1.2f;
+
+        public readonly Bindable<Visibility> CornerPieceVisibility = new Bindable<Visibility>(Visibility.Visible);
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;


### PR DESCRIPTION
Makes the RankedPlayScreen show the intro-screen during RoundWarmup stage for the first round, as well as hooking up the intro to the MultiplayerClient so it uses the actual players present in the match.

Also gives Subscreens the ability to show/hide the corner pieces containing the user avatars.


https://github.com/user-attachments/assets/ad1a499a-6a38-4c21-9a29-11c0c02515bf


https://github.com/user-attachments/assets/75fb0d6c-98ac-4d50-8aea-c4bc4e88066f

