### PR TITLE
Add basic results screen implementation

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScoreWedge.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneResultsScoreWedge.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions;
+using osu.Framework.Utils;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Online.Rooms;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Tests.Visual.Multiplayer;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public partial class TestSceneResultsScoreWedge : MultiplayerTestScene
+    {
+        private RankedPlayScreen screen = null!;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            setupRequestHandler();
+
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.RankedPlay)));
+            WaitForJoined();
+
+            AddStep("add other user", () => MultiplayerClient.AddUser(new MultiplayerRoomUser(2)));
+
+            AddStep("load screen", () => LoadScreen(screen = new RankedPlayScreen(MultiplayerClient.ClientRoom!)));
+            AddUntilStep("screen loaded", () => screen.IsLoaded);
+
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Results).WaitSafely());
+        }
+
+        private void setupRequestHandler()
+        {
+            AddStep("setup request handler", () =>
+            {
+                Func<APIRequest, bool>? defaultRequestHandler = ((DummyAPIAccess)API).HandleRequest;
+
+                ((DummyAPIAccess)API).HandleRequest = request =>
+                {
+                    switch (request)
+                    {
+                        case IndexPlaylistScoresRequest index:
+                            var result = new IndexedMultiplayerScores();
+
+                            foreach (int userId in new[] { 2, API.LocalUser.Value.OnlineID })
+                            {
+                                result.Scores.Add(new MultiplayerScore
+                                {
+                                    ID = userId,
+                                    Accuracy = RNG.NextSingle(),
+                                    EndedAt = DateTimeOffset.Now,
+                                    Passed = true,
+                                    Rank = (ScoreRank)RNG.Next((int)ScoreRank.D, (int)ScoreRank.XH),
+                                    MaxCombo = RNG.Next(1000),
+                                    TotalScore = RNG.Next(1_000_000),
+                                    Statistics = new Dictionary<HitResult, int>
+                                    {
+                                        [HitResult.Miss] = 1,
+                                        [HitResult.Meh] = 50,
+                                        [HitResult.Ok] = 100,
+                                        [HitResult.Good] = 200,
+                                        [HitResult.Great] = 300,
+                                        [HitResult.Perfect] = 320,
+                                        [HitResult.SmallTickHit] = 50,
+                                        [HitResult.SmallTickMiss] = 25,
+                                        [HitResult.LargeTickHit] = 100,
+                                        [HitResult.LargeTickMiss] = 50,
+                                        [HitResult.SmallBonus] = 10,
+                                        [HitResult.LargeBonus] = 50
+                                    },
+                                    MaximumStatistics = new Dictionary<HitResult, int>
+                                    {
+                                        [HitResult.Perfect] = 971,
+                                        [HitResult.SmallTickHit] = 75,
+                                        [HitResult.LargeTickHit] = 150,
+                                        [HitResult.SmallBonus] = 10,
+                                        [HitResult.LargeBonus] = 50,
+                                    },
+                                    User = new APIUser
+                                    {
+                                        Id = userId,
+                                        Username = $"user {userId}",
+                                    }
+                                });
+                            }
+
+                            index.TriggerSuccess(result);
+                            return true;
+
+                        default:
+                            return defaultRequestHandler?.Invoke(request) ?? false;
+                    }
+                };
+            });
+        }
+    }
+}

--- a/osu.Game/Online/Leaderboards/DrawableRank.cs
+++ b/osu.Game/Online/Leaderboards/DrawableRank.cs
@@ -115,5 +115,36 @@ namespace osu.Game.Online.Leaderboards
                     return Color4Extensions.FromHex(@"CC3333");
             }
         }
+
+        public static string GetLegacyRankTextureName(ScoreRank rank)
+        {
+            switch (rank)
+            {
+                case ScoreRank.XH:
+                    return "ranking-XH";
+
+                case ScoreRank.SH:
+                    return "ranking-SH";
+
+                case ScoreRank.X:
+                    return "ranking-X";
+
+                case ScoreRank.S:
+                    return "ranking-S";
+
+                case ScoreRank.A:
+                    return "ranking-A";
+
+                case ScoreRank.B:
+                    return "ranking-B";
+
+                case ScoreRank.C:
+                    return "ranking-C";
+
+                default:
+                case ScoreRank.D:
+                    return "ranking-D";
+            }
+        }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -240,6 +240,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     ShowScreen(new GameplayWarmupScreen());
                     break;
 
+                case RankedPlayStage.Results:
+                    ShowScreen(new ResultsScreen());
+                    break;
+
                 default:
                     ShowScreen(new PlaceholderScreen(stage));
                     break;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.BlueScoreWedge.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.BlueScoreWedge.cs
@@ -1,0 +1,85 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Scoring;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class ResultsScreen
+    {
+        private partial class BlueScoreWedge : CompositeDrawable
+        {
+            private readonly ScoreInfo score;
+
+            public BlueScoreWedge(ScoreInfo score)
+            {
+                this.score = score;
+
+                RelativeSizeAxes = Axes.X;
+                Size = new Vector2(0.51f, 160);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                float shearWidth = OsuGame.SHEAR.X * Height;
+
+                InternalChildren = new Drawable[]
+                {
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding
+                        {
+                            Left = -300,
+                            Right = -shearWidth
+                        },
+                        Child = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Shear = OsuGame.SHEAR,
+                            Masking = true,
+                            CornerRadius = 8,
+                            Child = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Black,
+                                Alpha = 0.5f,
+                            }
+                        }
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding { Horizontal = 20 },
+                        Y = -25,
+                        ColumnDimensions =
+                        [
+                            new Dimension(),
+                            new Dimension(GridSizeMode.Absolute, 20),
+                            new Dimension(GridSizeMode.AutoSize)
+                        ],
+                        Content = new[]
+                        {
+                            new Drawable?[]
+                            {
+                                new ScoreStatisticsDisplay(score, RankedPlayColourScheme.Blue),
+                                null,
+                                new ScoreRankDisplay(score)
+                                {
+                                    Y = 60,
+                                }
+                            }
+                        }
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.RedScoreWedge.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.RedScoreWedge.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Scoring;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class ResultsScreen
+    {
+        private partial class RedScoreWedge : CompositeDrawable
+        {
+            private readonly ScoreInfo score;
+
+            public RedScoreWedge(ScoreInfo score)
+            {
+                this.score = score;
+
+                RelativeSizeAxes = Axes.X;
+                Size = new Vector2(0.51f, 160);
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                float shearWidth = OsuGame.SHEAR.X * Height;
+
+                InternalChildren = new Drawable[]
+                {
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding
+                        {
+                            Left = -shearWidth,
+                            Right = -300,
+                        },
+                        Child = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Shear = OsuGame.SHEAR,
+                            Masking = true,
+                            CornerRadius = 8,
+                            Child = new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Black,
+                                Alpha = 0.5f,
+                            }
+                        }
+                    },
+                    new GridContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Padding = new MarginPadding
+                        {
+                            Left = -shearWidth + 20,
+                            Right = 20 + shearWidth
+                        },
+                        Y = -25,
+                        ColumnDimensions =
+                        [
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension(GridSizeMode.Absolute, 20),
+                            new Dimension()
+                        ],
+                        Content = new[]
+                        {
+                            new Drawable?[]
+                            {
+                                new ScoreRankDisplay(score)
+                                {
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomLeft,
+                                },
+                                null,
+                                new ScoreStatisticsDisplay(score, RankedPlayColourScheme.Red)
+                            }
+                        }
+                    },
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.ScoreRankDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.ScoreRankDisplay.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Online.Leaderboards;
+using osu.Game.Scoring;
+using osu.Game.Skinning;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class ResultsScreen
+    {
+        private partial class ScoreRankDisplay : CompositeDrawable
+        {
+            private readonly ScoreInfo score;
+
+            public ScoreRankDisplay(ScoreInfo score)
+            {
+                this.score = score;
+
+                AutoSizeAxes = Axes.Both;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(SkinManager skinManager)
+            {
+                InternalChild = new Sprite
+                {
+                    Scale = new Vector2(0.5f),
+                    Texture = skinManager.DefaultClassicSkin.GetTexture(DrawableRank.GetLegacyRankTextureName(score.Rank))
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.ScoreStatisticsDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.ScoreStatisticsDisplay.cs
@@ -1,0 +1,78 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Scoring;
+using osu.Game.Screens.SelectV2;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class ResultsScreen
+    {
+        private partial class ScoreStatisticsDisplay : CompositeDrawable
+        {
+            private readonly ScoreInfo score;
+            private readonly RankedPlayColourScheme colours;
+
+            private FillFlowContainer<BeatmapTitleWedge.StatisticDifficulty> statisticsFlow = null!;
+
+            public ScoreStatisticsDisplay(ScoreInfo score, RankedPlayColourScheme colours)
+            {
+                this.score = score;
+                this.colours = colours;
+
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                InternalChild = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(20),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = score.TotalScore.ToString("N0"),
+                            Font = OsuFont.Torus.With(size: 72),
+                            UseFullGlyphHeight = false,
+                        },
+                        statisticsFlow = new FillFlowContainer<BeatmapTitleWedge.StatisticDifficulty>
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Spacing = new Vector2(10, 20),
+                            Children = score.GetStatisticsForDisplay().Select(it => new BeatmapTitleWedge.StatisticDifficulty
+                            {
+                                Width = 80,
+                                Value = new BeatmapTitleWedge.StatisticDifficulty.Data(it.DisplayName, it.Count, it.Count, it.MaxCount ?? it.Count),
+                                AccentColour = colours.PrimaryDarker
+                            }).ToArray(),
+                        }
+                    }
+                };
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                int statisticsPerRow = (statisticsFlow.Count + 1) / 2;
+                float statisticWidth = (DrawWidth - (statisticsPerRow - 1) * statisticsFlow.Spacing.X) / statisticsPerRow;
+                foreach (var statistic in statisticsFlow)
+                    statistic.Width = statisticWidth;
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
@@ -1,0 +1,159 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
+using osu.Game.Beatmaps;
+using osu.Game.Database;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Models;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
+using osu.Game.Scoring;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class ResultsScreen : RankedPlaySubScreen
+    {
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
+
+        [Resolved]
+        private ScoreManager scoreManager { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesets { get; set; } = null!;
+
+        private Container<Drawable> wedgeContainer = null!;
+        private LoadingSpinner loadingSpinner = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new Drawable[]
+            {
+                wedgeContainer = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(20),
+                    Rotation = -2f,
+                },
+                loadingSpinner = new LoadingSpinner
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            loadingSpinner.Show();
+
+            queryScores().FireAndForget();
+        }
+
+        private async Task queryScores()
+        {
+            try
+            {
+                if (client.Room == null)
+                    return;
+
+                Task<APIBeatmap?> beatmapTask = beatmapLookupCache.GetBeatmapAsync(client.Room.CurrentPlaylistItem.BeatmapID);
+                TaskCompletionSource<List<MultiplayerScore>> scoreTask = new TaskCompletionSource<List<MultiplayerScore>>();
+
+                var request = new IndexPlaylistScoresRequest(client.Room.RoomID, client.Room.Settings.PlaylistItemId);
+                request.Success += req => scoreTask.SetResult(req.Scores);
+                request.Failure += e => scoreTask.SetException(e);
+                api.Queue(request);
+
+                await Task.WhenAll(beatmapTask, scoreTask.Task).ConfigureAwait(false);
+
+                APIBeatmap? apiBeatmap = beatmapTask.GetResultSafely();
+                List<MultiplayerScore> apiScores = scoreTask.Task.GetResultSafely();
+
+                if (apiBeatmap == null)
+                    return;
+
+                // Reference: PlaylistItemResultsScreen
+                setScores(apiScores.Select(s => s.CreateScoreInfo(scoreManager, rulesets, new BeatmapInfo
+                {
+                    Difficulty = new BeatmapDifficulty(apiBeatmap.Difficulty),
+                    Metadata =
+                    {
+                        Artist = apiBeatmap.Metadata.Artist,
+                        Title = apiBeatmap.Metadata.Title,
+                        Author = new RealmUser
+                        {
+                            Username = apiBeatmap.Metadata.Author.Username,
+                            OnlineID = apiBeatmap.Metadata.Author.OnlineID,
+                        }
+                    },
+                    DifficultyName = apiBeatmap.DifficultyName,
+                    StarRating = apiBeatmap.StarRating,
+                    Length = apiBeatmap.Length,
+                    BPM = apiBeatmap.BPM
+                })).ToArray());
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Failed to load scores for playlist item.");
+                throw;
+            }
+            finally
+            {
+                Scheduler.Add(() => loadingSpinner.Hide());
+            }
+        }
+
+        private void setScores(ScoreInfo[] scores) => Scheduler.Add(() =>
+        {
+            ScoreInfo localUserScore = scores.SingleOrDefault(s => s.UserID == api.LocalUser.Value.OnlineID) ?? new ScoreInfo
+            {
+                Rank = ScoreRank.F
+            };
+
+            ScoreInfo otherUserScore = scores.SingleOrDefault(s => s.UserID != api.LocalUser.Value.OnlineID) ?? new ScoreInfo
+            {
+                Rank = ScoreRank.F
+            };
+
+            wedgeContainer.Children =
+            [
+                new RedScoreWedge(otherUserScore)
+                {
+                    Anchor = Anchor.CentreRight,
+                    Origin = Anchor.CentreRight,
+                },
+                new BlueScoreWedge(localUserScore)
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                },
+            ];
+        });
+    }
+}


### PR DESCRIPTION
- Depends on https://github.com/ppy/osu-resources/pull/400 (but will work without)

Just a very basic implementation, without any animations/etc.

| game | tests |
| --- | --- |
| <img width="1922" height="1036" alt="image" src="https://github.com/user-attachments/assets/f82bf817-1ee5-4f05-8c15-6fd510f423e5" /> | <img width="1407" height="957" alt="image" src="https://github.com/user-attachments/assets/f505cbb4-e21c-4eab-8a6d-42f65c234182" /> |
