### PR TITLE
Add basic end screen

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneEndedScreen.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneEndedScreen.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Tests.Visual.Multiplayer;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public partial class TestSceneEndedScreen : MultiplayerTestScene
+    {
+        private RankedPlayScreen screen = null!;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.RankedPlay)));
+            WaitForJoined();
+
+            AddStep("add other user", () => MultiplayerClient.AddUser(new MultiplayerRoomUser(2)));
+
+            AddStep("load screen", () => LoadScreen(screen = new RankedPlayScreen(MultiplayerClient.ClientRoom!)));
+            AddUntilStep("screen loaded", () => screen.IsLoaded);
+        }
+
+        [Test]
+        public void TestVictory()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Ended, s =>
+            {
+                s.WinningUserId = API.LocalUser.Value.OnlineID;
+                s.Users[API.LocalUser.Value.OnlineID].RatingAfter = 1520;
+                s.Users[2].RatingAfter = 1480;
+            }).WaitSafely());
+        }
+
+        [Test]
+        public void TestDefeat()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Ended, s =>
+            {
+                s.WinningUserId = 2;
+                s.Users[API.LocalUser.Value.OnlineID].RatingAfter = 1480;
+                s.Users[2].RatingAfter = 1520;
+            }).WaitSafely());
+        }
+
+        [Test]
+        public void TestDraw()
+        {
+            AddStep("set results state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.Ended, s =>
+            {
+                s.Users[API.LocalUser.Value.OnlineID].RatingAfter = 1480;
+                s.Users[2].RatingAfter = 1520;
+            }).WaitSafely());
+        }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayRoomState.cs
@@ -48,9 +48,18 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         public double StarRating { get; set; }
 
         /// <summary>
+        /// The winner of the match.
+        /// </summary>
+        [Key(6)]
+        public int? WinningUserId { get; set; }
+
+        /// <summary>
         /// The user currently playing a card.
         /// </summary>
         [IgnoreMember]
         public RankedPlayUserInfo ActiveUser => Users[ActiveUserId];
+
+        [IgnoreMember]
+        public RankedPlayUserInfo? WinningUser => WinningUserId == null ? null : Users[WinningUserId.Value];
     }
 }

--- a/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
+++ b/osu.Game/Online/Multiplayer/MatchTypes/RankedPlay/RankedPlayUserInfo.cs
@@ -28,5 +28,11 @@ namespace osu.Game.Online.Multiplayer.MatchTypes.RankedPlay
         /// </summary>
         [Key(2)]
         public List<RankedPlayCardItem> Hand { get; set; } = [];
+
+        /// <summary>
+        /// Rating after conclusion of the match.
+        /// </summary>
+        [Key(3)]
+        public int RatingAfter { get; set; }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/EndedScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/EndedScreen.cs
@@ -1,0 +1,199 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public partial class EndedScreen : RankedPlaySubScreen
+    {
+        [Resolved]
+        private RankedPlayMatchInfo matchInfo { get; set; } = null!;
+
+        private OsuSpriteText titleText = null!;
+        private Drawable titleSeparator = null!;
+        private OsuTextFlowContainer localRatingText = null!;
+        private OsuTextFlowContainer opponentRatingText = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            CenterColumn.Child = new FillFlowContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(20),
+                Children = new[]
+                {
+                    titleText = new OsuSpriteText
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Text = "VICTORY",
+                        Font = OsuFont.Torus.With(size: 100, weight: FontWeight.SemiBold),
+                        UseFullGlyphHeight = false,
+                        Colour = colours.Green1,
+                    },
+                    titleSeparator = new Box
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        RelativeSizeAxes = Axes.X,
+                        Height = 2,
+                        Colour = colours.Green1
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(2),
+                        Children = new Drawable[]
+                        {
+                            new Container
+                            {
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Shear = OsuGame.SHEAR,
+                                Masking = true,
+                                CornerRadius = 8,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Color4.Black,
+                                        Alpha = 0.5f
+                                    },
+                                    new Container
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Padding = new MarginPadding(10),
+                                        Shear = -OsuGame.SHEAR,
+                                        Children = new Drawable[]
+                                        {
+                                            localRatingText = new OsuTextFlowContainer(s => s.Font = OsuFont.Style.Heading1)
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            new Container
+                            {
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Shear = OsuGame.SHEAR,
+                                Masking = true,
+                                CornerRadius = 8,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Color4.Black,
+                                        Alpha = 0.5f
+                                    },
+                                    new Container
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Padding = new MarginPadding(10),
+                                        Shear = -OsuGame.SHEAR,
+                                        Children = new Drawable[]
+                                        {
+                                            opponentRatingText = new OsuTextFlowContainer
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    new FillFlowContainer
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Children = new Drawable[]
+                        {
+                            new ShearedButton(100)
+                            {
+                                Text = "Quit",
+                                Action = () => { },
+                                DarkerColour = colours.Red3,
+                                LighterColour = colours.Red4,
+                            },
+                            new ShearedButton(200)
+                            {
+                                Text = "Play Again",
+                                Action = () => { },
+                                DarkerColour = colours.Green3,
+                                LighterColour = colours.Green4,
+                            },
+                        }
+                    }
+                }
+            };
+
+            RankedPlayUserInfo localUser = matchInfo.RoomState.Users[Client.LocalUser!.UserID];
+            RankedPlayUserInfo otherUser = matchInfo.RoomState.Users.Values.Single(u => u != localUser);
+
+            if (matchInfo.RoomState.WinningUserId == null)
+            {
+                titleText.Text = "DRAW";
+                titleText.Colour = titleSeparator.Colour = colours.Orange1;
+            }
+            else if (matchInfo.RoomState.WinningUserId == Client.LocalUser!.UserID)
+            {
+                titleText.Text = "VICTORY";
+                titleText.Colour = titleSeparator.Colour = colours.Green1;
+            }
+            else
+            {
+                titleText.Text = "DEFEAT";
+                titleText.Colour = titleSeparator.Colour = colours.Red1;
+            }
+
+            localRatingText.AddText("Your Rating: ", s => s.Font = OsuFont.Style.Heading1.With(weight: FontWeight.Regular));
+            localRatingText.AddText(localUser.RatingAfter.ToString("N0"), s => s.Font = OsuFont.Style.Heading1);
+            localRatingText.AddText($" ({localUser.RatingAfter - localUser.Rating:+0;-0;+0})", s =>
+            {
+                s.Font = OsuFont.Style.Caption1;
+                s.Colour = localUser.RatingAfter >= localUser.Rating ? colours.GreenDark : colours.RedDark;
+            });
+
+            opponentRatingText.AddText("Opponent Rating: ", s => s.Font = OsuFont.Style.Heading1.With(weight: FontWeight.Regular));
+            opponentRatingText.AddText(otherUser.RatingAfter.ToString("N0"), s => s.Font = OsuFont.Style.Heading1);
+            opponentRatingText.AddText($" ({otherUser.RatingAfter - otherUser.Rating:+0;-0;+0})", s =>
+            {
+                s.Font = OsuFont.Style.Caption1;
+                s.Colour = otherUser.RatingAfter >= otherUser.Rating ? colours.GreenDark : colours.RedDark;
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -244,6 +244,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     ShowScreen(new ResultsScreen());
                     break;
 
+                case RankedPlayStage.Ended:
+                    ShowScreen(new EndedScreen());
+                    break;
+
                 default:
                     ShowScreen(new PlaceholderScreen(stage));
                     break;


### PR DESCRIPTION
No animations/etc, not even working with a design. Just getting something in place to figure out what's needed.

Since there's a finite deck and life points we need to consider the possibility of a draw, so there are 3 results possible/implemented here.

| victory | defeat | draw|
| --- | --- | --- |
| <img width="1676" height="963" alt="image" src="https://github.com/user-attachments/assets/2675a5c5-743e-4279-9582-0ee4c0a9b95d" /> | <img width="1679" height="962" alt="image" src="https://github.com/user-attachments/assets/5046d475-02ea-4153-a550-425570ed8406" /> | <img width="1678" height="961" alt="image" src="https://github.com/user-attachments/assets/179781b3-c272-4fb3-846a-865587e665e4" /> |