### PR TITLE
Improve offset applied to cards on hover

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using Humanizer;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Overlays;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public class TestScenePlayerCardHand : OsuTestScene
+    {
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+        private PlayerCardHand cardHand = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Child = cardHand = new PlayerCardHand
+            {
+                Anchor = Anchor.BottomCentre,
+                Origin = Anchor.BottomCentre,
+                RelativeSizeAxes = Axes.Both,
+                Height = 0.5f,
+            };
+        }
+
+        [Test]
+        public void TestCardCount()
+        {
+            for (int i = 1; i <= 8; i++)
+            {
+                int numCards = i;
+
+                AddStep($"{i} {"cards".Pluralize(i == 1)}", () =>
+                {
+                    foreach (var card in cardHand.Cards.ToArray())
+                        cardHand.RemoveCard(card.Card.Item);
+
+                    for (int j = 0; j < numCards; j++)
+                        cardHand.AddCard(new RankedPlayCardWithPlaylistItem(new RankedPlayCardItem()));
+                });
+            }
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestScenePlayerCardHand.cs
@@ -13,7 +13,7 @@ using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards;
 
 namespace osu.Game.Tests.Visual.RankedPlay
 {
-    public class TestScenePlayerCardHand : OsuTestScene
+    public partial class TestScenePlayerCardHand : OsuTestScene
     {
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/CardHand.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/CardHand.cs
@@ -167,31 +167,53 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
 
             float x = -totalWidth / 2;
 
-            if (cardContainer.Any(it => it.CardHovered))
-                x -= 20;
+            const int no_card_hovered = -1;
+            int hoverIndex = no_card_hovered;
 
-            float xOffset = 0;
+            for (int i = 0; i < cardContainer.Count; i++)
+            {
+                if (cardContainer[i].CardHovered)
+                {
+                    hoverIndex = i;
+                    break;
+                }
+            }
+
             double delay = 0;
 
-            foreach (var child in cardContainer)
+            for (int i = 0; i < cardContainer.Count; i++)
             {
+                var child = cardContainer[i];
+
                 x += child.LayoutWidth / 2;
 
                 float yOffset = 0;
 
                 var position = new Vector2(x, MathF.Pow(MathF.Abs(x / 250), 2) * 20 + 10);
 
+                if (hoverIndex != no_card_hovered && cardContainer.Children.Count > 1)
+                {
+                    int distance = Math.Abs(i - hoverIndex);
+                    int direction = Math.Sign(i - hoverIndex);
+
+                    position.X += direction switch
+                    {
+                        0 => -10,
+
+                        // special case for the left card when there's only 2 cards
+                        // too much offset looks kinda odd here so it's reduced
+                        < 0 when cardContainer.Count == 2 => -3,
+
+                        < 0 => -10 / MathF.Pow(distance, 3),
+
+                        // cards right to the hovered card have a higher offset because they are partially
+                        // covering the cards to their left
+                        > 0 => 20 / MathF.Pow(distance, 2),
+                    };
+                }
+
                 if (child.CardHovered)
-                {
-                    x += 30;
-                    xOffset = 30;
                     yOffset = -HoverYOffset;
-                }
-                else
-                {
-                    x -= xOffset / 2;
-                    xOffset /= 2;
-                }
 
                 float rotation = x * 0.03f;
 


### PR DESCRIPTION
Fixes the issue with the card shifting to the left on hover when only one card is remaining.
Algorithm also now determines the offset based on it's index relative to the hovered card instead of keeping a running value, primarily to make it easier to deal with edge cases.

https://github.com/user-attachments/assets/39cff942-3702-4ffb-9366-420a38b8de65

