### PR TITLE
Apply audio ducking during intro screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
@@ -5,6 +5,8 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Database;
@@ -31,6 +33,16 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
         [Resolved]
         private MusicController? musicController { get; set; }
+
+        private Sample? windupSample;
+        private Sample? impactSample;
+
+        [BackgroundDependencyLoader]
+        private void load(AudioManager audio)
+        {
+            windupSample = audio.Samples.Get("Results/swoosh-up");
+            impactSample = audio.Samples.Get("Results/rank-impact-pass");
+        }
 
         protected override void LoadComplete()
         {
@@ -66,7 +78,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
         public void PlayIntroSequence(UserWithRating player, UserWithRating opponent, double starRating)
         {
-            double delay = 0;
+            // 1500ms delay added temporarily to account for the windup placeholder sample's duration
+            double delay = 1500;
 
             var vsScreen = new VsSequence(player, opponent);
 
@@ -80,6 +93,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
             {
                 DuckDuration = impactDelay
             });
+
+            if (windupSample != null)
+            {
+                Scheduler.AddDelayed(() => windupSample?.Play(), impactDelay - windupSample.Length);
+                Scheduler.AddDelayed(() => impactSample?.Play(), impactDelay);
+            }
 
             Scheduler.AddDelayed(() => CornerPieceVisibility.Value = Visibility.Visible, delay);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/VsSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/VsSequence.cs
@@ -127,7 +127,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
             ];
         }
 
-        public void Play(ref double delay)
+        public void Play(ref double delay, out double impactDelay)
         {
             using (BeginDelayedSequence(delay))
             {
@@ -138,6 +138,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
             }
 
             delay += 850;
+
+            impactDelay = delay;
 
             using (BeginDelayedSequence(delay))
             {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -464,9 +464,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 return;
 
             beatmap.NewValue.PrepareTrackForPreview(true);
-#if (!DEBUG)
             music.EnsurePlayingSomething();
-#endif
         }
 
         public void PresentBeatmap(WorkingBeatmap beatmap, RulesetInfo ruleset)


### PR DESCRIPTION
Applies audio ducking during the intro. Alls adds some some placeholder samples so there's something to work with here audio-wise.
Note that the windup sample is so long that I had to delay the intro start by 1500ms, should be reverted once actual sounds are in place.


https://github.com/user-attachments/assets/bb874774-1723-4648-8937-328433be3f16

