### PR TITLE
Fix broken alpha-blending in `RankedPlayCornerPiece`

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayCornerPiece.cs
@@ -66,6 +66,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = colourScheme.PrimaryDarkest,
                                     Alpha = 0.2f,
+                                    // This is a hack to work around alpha-blending issues when drawing on top of a transparent background without premultiplied alpha
+                                    // This method requires that this Drawable is not drawn on top of anything else
+                                    Blending = BlendingParameters.Mixture with
+                                    {
+                                        Destination = BlendingType.Zero,
+                                        DestinationAlpha = BlendingType.Zero,
+                                        Source = BlendingType.One,
+                                        SourceAlpha = BlendingType.One,
+                                    }
                                 },
                             },
                             topLayer = new Container


### PR DESCRIPTION
Caused by #168, where wrapping this drawable in a `BufferedContainer` introduced alpha-blending issues and made the bottom layer loose almost all saturation.
Workaround works by basically turning off alpha blending completely for the first drawable drawn to the framebuffer.

### Before

<img width="430" height="142" alt="image" src="https://github.com/user-attachments/assets/a112b02a-7112-45e4-b969-c1924bfd2a19" />
<img width="471" height="181" alt="image" src="https://github.com/user-attachments/assets/1699ba28-67c8-4ea3-8549-712b8d552f57" />

### After

<img width="454" height="152" alt="image" src="https://github.com/user-attachments/assets/6d2e272e-e793-44a0-87e8-c7121e22c5e4" />

<img width="413" height="211" alt="image" src="https://github.com/user-attachments/assets/3bd5ce2e-27df-459f-85b0-fc7d394c4db5" />

