### PR TITLE
Make beatmap author link non-clickable

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/RankedPlayCardContent.Metadata.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/RankedPlayCardContent.Metadata.cs
@@ -56,7 +56,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
 
                         d.NewParagraph();
                         d.AddText("mapped by ", static s => s.Font = OsuFont.GetFont(size: 9, weight: FontWeight.SemiBold));
-                        d.AddUserLink(beatmap.Metadata.Author, static s => s.Font = OsuFont.GetFont(size: 9, weight: FontWeight.SemiBold));
+                        d.AddText(beatmap.Metadata.Author.Username, s =>
+                        {
+                            s.Font = OsuFont.GetFont(size: 9, weight: FontWeight.SemiBold);
+                            s.Colour = colours.OnBackground;
+                        });
                     }),
                 ];
             }


### PR DESCRIPTION
Closes ppy/osu#36540

Also switched the colour to the same one as the difficulty name.

<img width="524" height="377" alt="image" src="https://github.com/user-attachments/assets/0f7202a1-a9a9-4bdc-83b0-d5aedce0bc68" />
