### PR TITLE
Fix alpha blending issues in RankedPlayUserDisplay hp text

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -244,6 +244,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                     {
                         RelativeSizeAxes = Axes.Both,
                         Shear = -OsuGame.SHEAR,
+                        BackgroundColour = Color4.White.Opacity(0), // workaround for non-premultiplied alpha blending of white content on transparent background
                         Child = new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.Both,


### PR DESCRIPTION
Yet another alpha-blending fix

Closes ppy/osu#36546

### Before:

<img width="429" height="143" alt="image" src="https://github.com/user-attachments/assets/677b9f34-ee02-4e02-8f02-bcf4fd699ac8" />

### After:

<img width="433" height="147" alt="image" src="https://github.com/user-attachments/assets/8f4e5984-de2b-4d06-9cf5-f045ff5591f2" />
t