### PR TITLE
Add keyboard shortcuts for card selection

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/CardHand.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/CardHand.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
             }
         }
 
-        private bool contracted;
+        protected bool Contracted { get; private set; }
 
         /// <summary>
         /// Contracts all cards towards the bottom (or top when <see cref="Flipped"/>).
@@ -70,7 +70,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
         /// </summary>
         public void Contract()
         {
-            contracted = true;
+            Contracted = true;
 
             double delay = 0;
 
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
 
         private void updateLayout(double stagger = 0)
         {
-            if (contracted)
+            if (Contracted)
                 return;
 
             const float spacing = -20;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/CardHand.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/CardHand.cs
@@ -144,7 +144,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
 
         protected virtual HandCard CreateHandCard(RankedPlayCard card) => new HandCard(card);
 
-        protected virtual void OnCardStateChanged(HandCard card, RankedPlayCardState state) => InvalidateLayout();
+        protected virtual void OnCardStateChanged(HandCard card, RankedPlayCardState state)
+        {
+            InvalidateLayout();
+
+            // hovered state can be caused by keyboard focus, in which case we have to clean up after the other cards manually
+            if (state.Hovered)
+            {
+                foreach (var c in cardContainer)
+                {
+                    if (c != card)
+                        c.CardHovered = false;
+                }
+            }
+        }
 
         #region Layout
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/PlayerCardHand.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/PlayerCardHand.cs
@@ -187,6 +187,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
         {
             int currentIndex = Cards.ToList().FindIndex(c => c.HasFocus);
 
+            // default behaviour is to start from either end of the cards if no card is focused currently
+            // in single-selection mode we can however use the current selection as a fallback index if there's no focus
+            if (selectionMode == CardSelectionMode.Single && currentIndex == -1)
+                currentIndex = Cards.ToList().FindIndex(c => c.Selected);
+
             int newIndex = currentIndex + direction;
 
             if (newIndex < 0)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/PlayerCardHand.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/PlayerCardHand.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (e.Repeat)
+            if (e.Repeat || Contracted)
                 return false;
 
             switch (e.Key)
@@ -162,6 +162,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
                     return true;
 
                 case Key.Space:
+                    if (selectionMode == CardSelectionMode.Disabled)
+                        return false;
+
                     if (Cards.FirstOrDefault(it => it.HasFocus) is not PlayerHandCard card)
                         return false;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/PlayerCardHand.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Cards/PlayerCardHand.cs
@@ -168,10 +168,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
                     if (Cards.FirstOrDefault(it => it.HasFocus) is not PlayerHandCard card)
                         return false;
 
-                    if (card.PlayAction == null)
-                        card.TriggerClick();
+                    if (card.Selected)
+                        card.PlayButton.TriggerClick();
                     else
-                        card.PlayAction();
+                        card.TriggerClick();
+
                     return true;
 
                 case Key.Left:
@@ -228,7 +229,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
                 set
                 {
                     playAction = value;
-                    playButton.Action = value;
+                    PlayButton.Action = value;
                     updatePlayButtonVisibility();
                 }
             }
@@ -240,7 +241,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
             private readonly Drawable cardInputArea;
             private readonly Drawable fullInputArea;
 
-            private readonly ShearedButton playButton;
+            public readonly ShearedButton PlayButton;
 
             public PlayerHandCard(RankedPlayCard card)
                 : base(card)
@@ -263,7 +264,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
                         Child = fullInputArea = new Container
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Child = playButton = new ShearedButton(width: 90f, height: 30f)
+                            Child = PlayButton = new ShearedButton(width: 90f, height: 30f)
                             {
                                 Name = "Play Button",
                                 Anchor = Anchor.TopCentre,
@@ -293,12 +294,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards
 
             private void updatePlayButtonVisibility()
             {
-                playButton.Alpha = playButton.Action != null && Selected ? 1 : 0;
+                PlayButton.Alpha = PlayButton.Action != null && Selected ? 1 : 0;
             }
 
             public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
             {
-                if (playButton.Alpha > 0)
+                if (PlayButton.Alpha > 0)
                     return fullInputArea.ReceivePositionalInputAt(screenSpacePos);
 
                 // input events are handled for an area that's slightly larger than the actual card so the cursor always hovers a card when moving over a gap between two cards


### PR DESCRIPTION
Allows selecting cards via keyboard shortcuts.
Primarily doing this one cuz I personally want to this feature.

Uses focus under the hood. In single selection mode a card automatically enters selected state when gaining focus.

### Keybinds:
1-9 -> Move focus to nth card
left/right arrow -> Move focus to previous/next card
space -> toggles selection on discard screen, plays the card on the play screen

This doesn't trigger the song preview but it probably should
Probably best to wait until #182 is merged before merging this one so I can add that first

@peppy the space bar behaviour here feels like something where u could be imagining something else so you might wanna give this one a quick try (`TestSceneDiscardScreen` and `TestScenePickScreen`).