### PR TITLE
Integrate beatmap background into screen background on appropriate screens

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
@@ -39,6 +39,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private Drawable detailsColumn = null!;
         private Drawable wedgesContainer = null!;
 
+        public GameplayWarmupScreen()
+        {
+            ShowBeatmapBackground.Value = true;
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
@@ -22,6 +22,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class GameplayWarmupScreen : RankedPlaySubScreen
     {
+        public override bool ShowBeatmapBackground => true;
+
         [Cached(typeof(IBindable<SongSelect.BeatmapSetLookupResult?>))]
         private readonly Bindable<SongSelect.BeatmapSetLookupResult?> lastLookupResult = new Bindable<SongSelect.BeatmapSetLookupResult?>();
 
@@ -38,11 +40,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private Drawable separator = null!;
         private Drawable detailsColumn = null!;
         private Drawable wedgesContainer = null!;
-
-        public GameplayWarmupScreen()
-        {
-            ShowBeatmapBackground.Value = true;
-        }
 
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBackgroundScreen.cs
@@ -1,14 +1,27 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Transforms;
+using osu.Game.Beatmaps;
+using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class RankedPlayBackgroundScreen : BackgroundScreen
     {
         public RankedPlayBackground Background { get; }
+
+        [Resolved]
+        private Bindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+        public Bindable<bool> ShowBeatmapBackground { get; } = new BindableBool();
 
         public RankedPlayBackgroundScreen()
         {
@@ -19,6 +32,79 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 GradientInside = Color4Extensions.FromHex("#71308F"),
                 DotsColour = Color4Extensions.FromHex("#CC46F6").Opacity(0.5f),
             };
+        }
+
+        private CancellationTokenSource? pendingBackgroundLoad;
+        private BeatmapBackground? currentBackground;
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            beatmap.BindValueChanged(_ => updateBackground());
+            ShowBeatmapBackground.BindValueChanged(_ => updateBackground());
+            updateBackground();
+        }
+
+        private void updateBackground()
+        {
+            pendingBackgroundLoad?.Cancel();
+
+            if (beatmap.Value == null || !ShowBeatmapBackground.Value)
+            {
+                currentBackground?.PopOut().Expire();
+                currentBackground = null;
+                return;
+            }
+
+            pendingBackgroundLoad = new CancellationTokenSource();
+
+            LoadComponentAsync(new BeatmapBackground(beatmap.Value), background =>
+            {
+                currentBackground?.PopOut().Expire();
+
+                AddInternal(background);
+                currentBackground = background;
+
+                background.PopIn();
+            }, pendingBackgroundLoad.Token);
+        }
+
+        [LongRunningLoad]
+        private partial class BeatmapBackground(WorkingBeatmap beatmap) : CompositeDrawable
+        {
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RelativeSizeAxes = Axes.Both;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                InternalChild = new BufferedContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    FrameBufferScale = new Vector2(0.15f),
+                    GrayscaleStrength = 0.3f,
+                    BlurSigma = new Vector2(5),
+                    Colour = Color4Extensions.FromHex("#cccccc"),
+                    Child = new Sprite
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Texture = beatmap.GetBackground(),
+                        FillMode = FillMode.Fill,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                };
+            }
+
+            public void PopIn() => this.FadeOut()
+                                       .FadeTo(0.4f, 300)
+                                       .ScaleTo(1.2f)
+                                       .ScaleTo(1f, 600, Easing.OutExpo);
+
+            public TransformSequence<BeatmapBackground> PopOut() =>
+                this.FadeOut(300).ScaleTo(1.1f, 600, Easing.OutExpo);
         }
     }
 }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBackgroundScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayBackgroundScreen.cs
@@ -80,7 +80,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
 
-                InternalChild = new BufferedContainer
+                InternalChild = new BufferedContainer(cachedFrameBuffer: true)
                 {
                     RelativeSizeAxes = Axes.Both,
                     FrameBufferScale = new Vector2(0.15f),

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -50,7 +50,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public RankedPlaySubScreen? ActiveSubScreen { get; private set; }
 
-        protected override BackgroundScreen CreateBackground() => new RankedPlayBackgroundScreen();
+        protected override BackgroundScreen CreateBackground() => new RankedPlayBackgroundScreen
+        {
+            ShowBeatmapBackground = { BindTarget = showBeatmapBackground }
+        };
 
         public override float BackgroundParallaxAmount => 0;
 
@@ -101,6 +104,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private int? lastDownloadCheckedBeatmapId;
 
         private readonly Bindable<Visibility> cornerPieceVisibility = new Bindable<Visibility>();
+        private readonly Bindable<bool> showBeatmapBackground = new Bindable<bool>();
 
         [Cached]
         private readonly RankedPlayMatchInfo matchInfo;
@@ -220,9 +224,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 previousScreen?.Expire();
 
                 if (previousScreen != null)
+                {
                     cornerPieceVisibility.UnbindFrom(previousScreen.CornerPieceVisibility);
+                    showBeatmapBackground.UnbindFrom(previousScreen.ShowBeatmapBackground);
+                }
 
                 cornerPieceVisibility.BindTo(screen.CornerPieceVisibility);
+                showBeatmapBackground.BindTo(screen.ShowBeatmapBackground);
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -224,13 +224,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 previousScreen?.Expire();
 
                 if (previousScreen != null)
-                {
                     cornerPieceVisibility.UnbindFrom(previousScreen.CornerPieceVisibility);
-                    showBeatmapBackground.UnbindFrom(previousScreen.ShowBeatmapBackground);
-                }
 
                 cornerPieceVisibility.BindTo(screen.CornerPieceVisibility);
-                showBeatmapBackground.BindTo(screen.ShowBeatmapBackground);
+                showBeatmapBackground.Value = screen.ShowBeatmapBackground;
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public readonly Bindable<Visibility> CornerPieceVisibility = new Bindable<Visibility>(Visibility.Visible);
 
-        public readonly Bindable<bool> ShowBeatmapBackground = new Bindable<bool>();
+        public virtual bool ShowBeatmapBackground => false;
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlaySubScreen.cs
@@ -19,6 +19,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         public readonly Bindable<Visibility> CornerPieceVisibility = new Bindable<Visibility>(Visibility.Visible);
 
+        public readonly Bindable<bool> ShowBeatmapBackground = new Bindable<bool>();
+
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
@@ -48,6 +48,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private Container<Drawable> wedgeContainer = null!;
         private LoadingSpinner loadingSpinner = null!;
 
+        public ResultsScreen()
+        {
+            ShowBeatmapBackground.Value = true;
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/ResultsScreen.cs
@@ -27,6 +27,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class ResultsScreen : RankedPlaySubScreen
     {
+        public override bool ShowBeatmapBackground => true;
+
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
@@ -47,11 +49,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private Container<Drawable> wedgeContainer = null!;
         private LoadingSpinner loadingSpinner = null!;
-
-        public ResultsScreen()
-        {
-            ShowBeatmapBackground.Value = true;
-        }
 
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
Overlays a blurred version of the beatmap background over the screen background on the `GameplayWarmupScreen` as well as `ResultsScreen`.

https://github.com/user-attachments/assets/9fc7b9a5-db48-4fc2-ac05-6cc8e64b5ddd

https://github.com/user-attachments/assets/ab2ce679-c7fc-4528-bccc-52d7c7e32871

