### PR TITLE
Add/improve SFX for ranked play

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayStageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayStageDisplay.cs
@@ -3,6 +3,8 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -41,6 +43,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private DateTimeOffset countdownStartTime;
         private DateTimeOffset countdownEndTime;
 
+        private Sample? timeRunningOutSample;
+        private SampleChannel? timeRunningOutSampleChannel;
+        private Sample? timeUpBuzzerSample;
+        private bool timeUpBuzzerActive = true;
+
+        // When the 'time running out' warning sample starts to play (in remaining seconds)
+        private const int warning_time_threshold = 10;
+
         public RankedPlayStageDisplay(RankedPlayColourScheme colourScheme)
         {
             this.colourScheme = colourScheme;
@@ -49,7 +59,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(AudioManager audio)
         {
             const float phase_text_background_height = 55;
             Vector2 progressBarSize = new Vector2(300, 25);
@@ -173,6 +183,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                     Font = OsuFont.TorusAlternate.With(size: 24, weight: FontWeight.SemiBold)
                 }
             };
+
+            timeRunningOutSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-running-out");
+            timeUpBuzzerSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-up");
         }
 
         protected override void LoadComplete()
@@ -206,6 +219,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             int ms = Math.Max(0, remaining.Milliseconds);
 
             progressText.Text = $"{minutes:00}:{seconds:00}.{ms:000}";
+
+            if (remaining.TotalSeconds <= 0)
+            {
+                timeRunningOutSampleChannel?.Stop();
+
+                if (!timeUpBuzzerActive) return;
+
+                timeUpBuzzerSample?.Play();
+                timeUpBuzzerActive = false;
+            }
+            else if (remaining.TotalSeconds < warning_time_threshold)
+            {
+                timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
+
+                if (timeRunningOutSampleChannel == null || timeRunningOutSampleChannel.Playing) return;
+
+                timeRunningOutSampleChannel.Looping = true;
+                timeRunningOutSampleChannel.Play();
+            }
         }
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
@@ -214,11 +246,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             {
                 countdownStartTime = DateTimeOffset.Now;
                 countdownEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
+                timeUpBuzzerActive = true;
             }
         });
 
         private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
+            timeRunningOutSampleChannel?.Stop();
+
             if (countdown is not RankedPlayStageCountdown)
                 return;
 
@@ -227,6 +262,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         protected override void Dispose(bool isDisposing)
         {
+            timeRunningOutSampleChannel?.Stop();
+
             base.Dispose(isDisposing);
 
             if (client.IsNotNull())

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/IntroScreen.cs
@@ -36,12 +36,14 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
         private Sample? windupSample;
         private Sample? impactSample;
+        private Sample? swooshSample;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            windupSample = audio.Samples.Get("Results/swoosh-up");
-            impactSample = audio.Samples.Get("Results/rank-impact-pass");
+            windupSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/vs-windup");
+            impactSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/vs-impact");
+            swooshSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/vs-swoosh");
         }
 
         protected override void LoadComplete()
@@ -78,8 +80,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
         public void PlayIntroSequence(UserWithRating player, UserWithRating opponent, double starRating)
         {
-            // 1500ms delay added temporarily to account for the windup placeholder sample's duration
-            double delay = 1500;
+            double delay = 0;
 
             var vsScreen = new VsSequence(player, opponent);
 
@@ -89,15 +90,13 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
             vsScreen.Play(ref delay, out double impactDelay);
 
-            duckOperation = musicController?.Duck(new DuckParameters
-            {
-                DuckDuration = impactDelay
-            });
+            duckOperation = musicController?.Duck();
 
             if (windupSample != null)
             {
                 Scheduler.AddDelayed(() => windupSample?.Play(), impactDelay - windupSample.Length);
                 Scheduler.AddDelayed(() => impactSample?.Play(), impactDelay);
+                Scheduler.AddDelayed(() => swooshSample?.Play(), impactDelay + 3200);
             }
 
             Scheduler.AddDelayed(() => CornerPieceVisibility.Value = Visibility.Visible, delay);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Intro/StarRatingSequence.cs
@@ -29,7 +29,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
         private OsuSpriteText explainer = null!;
 
         private Sample? tickSample;
-        private Sample? popInSample;
+        private Sample? tickFinalSample;
+        private Sample? ratingFoundSample;
+        private Sample? noticeSample;
+
+        private float lastTickStdDev;
 
         [BackgroundDependencyLoader]
         private void load(OsuColour colour, AudioManager audio)
@@ -135,8 +139,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                 }
             }
 
-            tickSample = audio.Samples.Get("UI/notch-tick");
-            popInSample = audio.Samples.Get("UI/notification-done");
+            tickSample = audio.Samples.Get("Multiplayer/Matchmaking/Ranked/star-rating-tick");
+            tickFinalSample = audio.Samples.Get("Multiplayer/Matchmaking/Ranked/star-rating-tick-final");
+            ratingFoundSample = audio.Samples.Get("Multiplayer/Matchmaking/Ranked/star-rating-found");
+            noticeSample = audio.Samples.Get("Multiplayer/Matchmaking/Ranked/star-rating-notice");
         }
 
         private float starRating { get; set; } = 5;
@@ -174,7 +180,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                 {
                     animateGaussianCurve = false;
 
-                    popInSample?.Play();
+                    ratingFoundSample?.Play();
 
                     var container = new FillFlowContainer
                     {
@@ -216,6 +222,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
 
                     creatingMapPool.FadeIn(100);
                     explainer.Delay(1050).FadeIn(100);
+                    Scheduler.AddDelayed(() =>
+                    {
+                        noticeSample?.Play();
+                    }, 1050);
                 });
             }
         }
@@ -296,18 +306,23 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Intro
                 return amplitude * MathF.Exp(-v2);
             }
 
-            if (Math.Abs(lastTickStdDev - stdDev) > 0.15)
+            if (Math.Abs(lastTickStdDev - stdDev) <= 0.075) return;
+
+            var tickChannel = tickSample!.GetChannel();
+            tickChannel.Frequency.Value = 1 + amplitude * 0.3f;
+            tickChannel.Volume.Value = 0.5 + amplitude * 0.5;
+            tickChannel.Play();
+
+            if (stdDev < 1)
             {
-                var channel = tickSample!.GetChannel();
-                channel.Frequency.Value = 1 + amplitude * 0.3f;
-                channel.Volume.Value = 0.5 + amplitude * 0.5;
-                channel.Play();
-
-                lastTickStdDev = stdDev;
+                var tickFinalChannel = tickFinalSample!.GetChannel();
+                tickFinalChannel.Frequency.Value = 1 + amplitude * 0.3f;
+                tickFinalChannel.Volume.Value = 0.1f + amplitude * 0.4f;
+                tickFinalChannel.Play();
             }
-        }
 
-        private float lastTickStdDev;
+            lastTickStdDev = stdDev;
+        }
 
         private partial class Bar : CircularContainer
         {


### PR DESCRIPTION
- Replaces placeholder SFX for `IntroScreen` & `StarRatingSequence`:

https://github.com/user-attachments/assets/97c0f75d-00d3-4f9b-9dca-3b5d88249372

- Adds a 'time running out' audible warning when 10 seconds remain, with a buzzer when time runs out:

https://github.com/user-attachments/assets/0a17360a-e522-4954-a02a-c0b3505a689a

10 seconds is a defined as a const, but not sure if this should be customisable or a dynamic % of time remaining or something? It's implemented as a looping sample, so any time threshold will work.

---

- [x] depends on ppy/osu-resources#407