### PR TITLE
Improve stage countdown warning sample playback

### DIFF
--- a/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingClient.cs
@@ -23,7 +23,18 @@ namespace osu.Game.Online.Matchmaking
         /// <see cref="IMatchmakingServer.MatchmakingDeclineInvitation">declined</see>,
         /// or ignored - in which case it will automatically be declined after a short timeout period.
         /// </summary>
+        /// <remarks>
+        /// Provided for compatibility with older clients - can be removed 20260825.
+        /// </remarks>
         Task MatchmakingRoomInvited();
+
+        /// <summary>
+        /// Signals that a match has been found and the local user is invited to it.
+        /// The invitation may be <see cref="IMatchmakingServer.MatchmakingAcceptInvitation">accepted</see>,
+        /// <see cref="IMatchmakingServer.MatchmakingDeclineInvitation">declined</see>,
+        /// or ignored - in which case it will automatically be declined after a short timeout period.
+        /// </summary>
+        Task MatchmakingRoomInvitedWithParams(MatchmakingRoomInvitationParams invitation);
 
         /// <summary>
         /// Signals that the matchmaking room is ready to be opened.

--- a/osu.Game/Online/Matchmaking/MatchmakingRoomInvitationParams.cs
+++ b/osu.Game/Online/Matchmaking/MatchmakingRoomInvitationParams.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingRoomInvitationParams
+    {
+        [Key(0)]
+        public MatchmakingPoolType Type { get; set; }
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -130,7 +130,7 @@ namespace osu.Game.Online.Multiplayer
 
         public event Action? MatchmakingQueueJoined;
         public event Action? MatchmakingQueueLeft;
-        public event Action? MatchmakingRoomInvited;
+        public event Action<MatchmakingRoomInvitationParams>? MatchmakingRoomInvited;
         public event Action<long, string>? MatchmakingRoomReady;
         public event Action<MatchmakingLobbyStatus>? MatchmakingLobbyStatusChanged;
         public event Action<MatchmakingQueueStatus>? MatchmakingQueueStatusChanged;
@@ -1098,7 +1098,13 @@ namespace osu.Game.Online.Multiplayer
 
         Task IMatchmakingClient.MatchmakingRoomInvited()
         {
-            Scheduler.Add(() => MatchmakingRoomInvited?.Invoke());
+            // Not implemented.
+            return Task.CompletedTask;
+        }
+
+        Task IMatchmakingClient.MatchmakingRoomInvitedWithParams(MatchmakingRoomInvitationParams invitation)
+        {
+            Scheduler.Add(() => MatchmakingRoomInvited?.Invoke(invitation));
             return Task.CompletedTask;
         }
 

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -77,7 +77,7 @@ namespace osu.Game.Online.Multiplayer
 
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueJoined), ((IMatchmakingClient)this).MatchmakingQueueJoined);
                     connection.On(nameof(IMatchmakingClient.MatchmakingQueueLeft), ((IMatchmakingClient)this).MatchmakingQueueLeft);
-                    connection.On(nameof(IMatchmakingClient.MatchmakingRoomInvited), ((IMatchmakingClient)this).MatchmakingRoomInvited);
+                    connection.On<MatchmakingRoomInvitationParams>(nameof(IMatchmakingClient.MatchmakingRoomInvitedWithParams), ((IMatchmakingClient)this).MatchmakingRoomInvitedWithParams);
                     connection.On<long, string>(nameof(IMatchmakingClient.MatchmakingRoomReady), ((IMatchmakingClient)this).MatchmakingRoomReady);
                     connection.On<MatchmakingLobbyStatus>(nameof(IMatchmakingClient.MatchmakingLobbyStatusChanged), ((IMatchmakingClient)this).MatchmakingLobbyStatusChanged);
                     connection.On<MatchmakingQueueStatus>(nameof(IMatchmakingClient.MatchmakingQueueStatusChanged), ((IMatchmakingClient)this).MatchmakingQueueStatusChanged);

--- a/osu.Game/Screens/Menu/ButtonSystem.cs
+++ b/osu.Game/Screens/Menu/ButtonSystem.cs
@@ -162,6 +162,7 @@ namespace osu.Game.Screens.Menu
             {
                 Padding = new MarginPadding { Left = WEDGE_WIDTH }
             });
+            buttonsMulti.Add(new MainMenuButton(ButtonSystemStrings.QuickPlay, @"button-daily-select", FontAwesome.Solid.Bolt, new Color4(94, 63, 186, 255), onQuickPlay, Key.Q));
             buttonsMulti.Add(new MainMenuButton(ButtonSystemStrings.RankedPlay, @"button-daily-select", FontAwesome.Solid.Crown, new Color4(94, 63, 186, 255), onRankedPlay, Key.R));
             buttonsMulti.ForEach(b => b.VisibleState = ButtonSystemState.Multi);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -95,15 +95,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             closeNotifications();
         });
 
-        private void onMatchmakingRoomInvited() => Scheduler.Add(() =>
+        private void onMatchmakingRoomInvited(MatchmakingRoomInvitationParams invitation) => Scheduler.Add(() =>
         {
             CurrentState.Value = ScreenQueue.MatchmakingScreenState.PendingAccept;
 
-            if (backgroundNotification != null)
-            {
-                backgroundNotification.State = ProgressNotificationState.Completed;
-                backgroundNotification = null;
-            }
+            backgroundNotification?.Complete(invitation);
+            backgroundNotification = null;
         });
 
         private void onMatchmakingRoomReady(long roomId, string password) => Scheduler.Add(() =>
@@ -184,18 +181,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     return false;
                 };
 
-                CompletionClickAction = () =>
-                {
-                    client.MatchmakingAcceptInvitation().FireAndForget();
-                    controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
-
-                    // Todo: Quick play value here is temporary. Needs some sort of signalling...
-                    performer?.PerformFromScreen(s => s.Push(new ScreenIntro(MatchmakingPoolType.QuickPlay)));
-
-                    Close(false);
-                    return true;
-                };
-
                 CancelRequested = () =>
                 {
                     client.MatchmakingLeaveQueue().FireAndForget();
@@ -203,6 +188,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 };
 
                 matchFoundSample = audio.Samples.Get(@"Multiplayer/Matchmaking/match-found");
+            }
+
+            public void Complete(MatchmakingRoomInvitationParams invitation)
+            {
+                CompletionClickAction = () =>
+                {
+                    client.MatchmakingAcceptInvitation().FireAndForget();
+                    controller.CurrentState.Value = ScreenQueue.MatchmakingScreenState.AcceptedWaitingForRoom;
+
+                    performer?.PerformFromScreen(s => s.Push(new ScreenIntro(invitation.Type)));
+
+                    Close(false);
+                    return true;
+                };
+
+                State = ProgressNotificationState.Completed;
             }
 
             protected override Notification CreateCompletionNotification()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayStageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayStageDisplay.cs
@@ -235,6 +235,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
                 if (timeRunningOutSampleChannel == null || timeRunningOutSampleChannel.Playing) return;
 
+                timeRunningOutSampleChannel.ManualFree = true;
                 timeRunningOutSampleChannel.Looping = true;
                 timeRunningOutSampleChannel.Play();
             }
@@ -263,6 +264,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         protected override void Dispose(bool isDisposing)
         {
             timeRunningOutSampleChannel?.Stop();
+            timeRunningOutSampleChannel?.Dispose();
 
             base.Dispose(isDisposing);
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayStageDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayStageDisplay.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Audio.Sample;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
@@ -42,14 +41,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         private DateTimeOffset countdownStartTime;
         private DateTimeOffset countdownEndTime;
-
-        private Sample? timeRunningOutSample;
-        private SampleChannel? timeRunningOutSampleChannel;
-        private Sample? timeUpBuzzerSample;
-        private bool timeUpBuzzerActive = true;
-
-        // When the 'time running out' warning sample starts to play (in remaining seconds)
-        private const int warning_time_threshold = 10;
 
         public RankedPlayStageDisplay(RankedPlayColourScheme colourScheme)
         {
@@ -183,9 +174,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                     Font = OsuFont.TorusAlternate.With(size: 24, weight: FontWeight.SemiBold)
                 }
             };
-
-            timeRunningOutSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-running-out");
-            timeUpBuzzerSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-up");
         }
 
         protected override void LoadComplete()
@@ -219,42 +207,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             int ms = Math.Max(0, remaining.Milliseconds);
 
             progressText.Text = $"{minutes:00}:{seconds:00}.{ms:000}";
-
-            if (remaining.TotalSeconds <= 0)
-            {
-                timeRunningOutSampleChannel?.Stop();
-
-                if (!timeUpBuzzerActive) return;
-
-                timeUpBuzzerSample?.Play();
-                timeUpBuzzerActive = false;
-            }
-            else if (remaining.TotalSeconds < warning_time_threshold)
-            {
-                timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
-
-                if (timeRunningOutSampleChannel == null || timeRunningOutSampleChannel.Playing) return;
-
-                timeRunningOutSampleChannel.ManualFree = true;
-                timeRunningOutSampleChannel.Looping = true;
-                timeRunningOutSampleChannel.Play();
-            }
         }
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            if (countdown is RankedPlayStageCountdown)
-            {
-                countdownStartTime = DateTimeOffset.Now;
-                countdownEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
-                timeUpBuzzerActive = true;
-            }
+            if (countdown is not RankedPlayStageCountdown)
+                return;
+
+            countdownStartTime = DateTimeOffset.Now;
+            countdownEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
         });
 
         private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            timeRunningOutSampleChannel?.Stop();
-
             if (countdown is not RankedPlayStageCountdown)
                 return;
 
@@ -263,9 +228,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
         protected override void Dispose(bool isDisposing)
         {
-            timeRunningOutSampleChannel?.Stop();
-            timeRunningOutSampleChannel?.Dispose();
-
             base.Dispose(isDisposing);
 
             if (client.IsNotNull())

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -45,6 +45,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
 
+        private bool timeRunningOutWarningActive;
         private Sample? timeRunningOutSample;
         private SampleChannel? timeRunningOutSampleChannel;
 
@@ -127,7 +128,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             matchInfo.PlayerCardRemoved += cardRemoved;
 
             playerHand.SelectionChanged += onSelectionChanged;
-            onSelectionChanged();
 
             Client.CountdownStarted += onCountdownStarted;
             Client.CountdownStopped += onCountdownStopped;
@@ -137,6 +137,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 foreach (var countdown in Client.Room.ActiveCountdowns)
                     onCountdownStarted(countdown);
             }
+
+            onSelectionChanged();
         }
 
         protected override void Update()
@@ -145,7 +147,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             TimeSpan remainingTime = stageEndTime - DateTimeOffset.Now;
 
-            if (remainingTime.TotalSeconds < warning_time_threshold)
+            if (timeRunningOutWarningActive && remainingTime.TotalSeconds < warning_time_threshold)
             {
                 timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
 
@@ -183,10 +185,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            if (countdown is not RankedPlayStageCountdown)
+            if (countdown is not RankedPlayStageCountdown stageCountdown)
                 return;
 
             stageEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
+            timeRunningOutWarningActive = stageCountdown.Stage == RankedPlayStage.CardDiscard;
         });
 
         private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
@@ -194,7 +197,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             if (countdown is not RankedPlayStageCountdown)
                 return;
 
+            timeRunningOutSampleChannel?.Stop();
+
             stageEndTime = DateTimeOffset.Now;
+            timeRunningOutWarningActive = false;
         });
 
         private void onSelectionChanged()
@@ -290,8 +296,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             double presentationTime = Math.Max(earliestPresentationTime, Time.Current);
             Scheduler.AddDelayed(presentRemainingCards, presentationTime - Time.Current);
-
-            timeRunningOutSampleChannel?.Stop();
         }
 
         private void presentRemainingCards()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/DiscardScreen.cs
@@ -17,6 +17,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osuTK;
@@ -26,6 +27,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class DiscardScreen : RankedPlaySubScreen
     {
+        // When the 'time running out' warning sample starts to play (in remaining seconds)
+        private const int warning_time_threshold = 10;
+
         public CardRow CenterRow { get; private set; } = null!;
 
         private PlayerCardHand playerHand = null!;
@@ -40,6 +44,11 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
+
+        private Sample? timeRunningOutSample;
+        private SampleChannel? timeRunningOutSampleChannel;
+
+        private DateTimeOffset stageEndTime;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
@@ -106,6 +115,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             cardPlaySamples = new Sample?[card_play_samples];
             for (int i = 0; i < card_play_samples; i++)
                 cardPlaySamples[i] = audio.Samples.Get($@"Multiplayer/Matchmaking/Ranked/card-play-{1 + i}");
+
+            timeRunningOutSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-running-out");
         }
 
         protected override void LoadComplete()
@@ -117,22 +128,34 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             playerHand.SelectionChanged += onSelectionChanged;
             onSelectionChanged();
+
+            Client.CountdownStarted += onCountdownStarted;
+            Client.CountdownStopped += onCountdownStopped;
+
+            if (Client.Room != null)
+            {
+                foreach (var countdown in Client.Room.ActiveCountdowns)
+                    onCountdownStarted(countdown);
+            }
         }
 
-        private void onSelectionChanged()
+        protected override void Update()
         {
-            if (playerHand.Selection.Any())
-                discardButton.Text = $"Replace {"card".ToQuantity(playerHand.Selection.Count())}";
-            else
-                discardButton.Text = "Keep cards";
-        }
+            base.Update();
 
-        private void onDiscardButtonClicked()
-        {
-            discardButton.Hide();
+            TimeSpan remainingTime = stageEndTime - DateTimeOffset.Now;
 
-            Client.DiscardCards(playerHand.Selection.Select(it => it.Card).ToArray()).FireAndForget();
-            playerHand.SelectionMode = CardSelectionMode.Disabled;
+            if (remainingTime.TotalSeconds < warning_time_threshold)
+            {
+                timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
+
+                if (timeRunningOutSampleChannel == null || timeRunningOutSampleChannel.Playing)
+                    return;
+
+                timeRunningOutSampleChannel.ManualFree = true;
+                timeRunningOutSampleChannel.Looping = true;
+                timeRunningOutSampleChannel.Play();
+            }
         }
 
         public override void OnEntering(RankedPlaySubScreen? previous)
@@ -156,6 +179,38 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             }
 
             playerHand.UpdateLayout(stagger: 50);
+        }
+
+        private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
+        {
+            if (countdown is not RankedPlayStageCountdown)
+                return;
+
+            stageEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
+        });
+
+        private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
+        {
+            if (countdown is not RankedPlayStageCountdown)
+                return;
+
+            stageEndTime = DateTimeOffset.Now;
+        });
+
+        private void onSelectionChanged()
+        {
+            if (playerHand.Selection.Any())
+                discardButton.Text = $"Replace {"card".ToQuantity(playerHand.Selection.Count())}";
+            else
+                discardButton.Text = "Keep cards";
+        }
+
+        private void onDiscardButtonClicked()
+        {
+            discardButton.Hide();
+
+            Client.DiscardCards(playerHand.Selection.Select(it => it.Card).ToArray()).FireAndForget();
+            playerHand.SelectionMode = CardSelectionMode.Disabled;
         }
 
         private readonly List<RankedPlayCardWithPlaylistItem> discardedCards = new List<RankedPlayCardWithPlaylistItem>();
@@ -234,8 +289,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             discardButton.Hide();
 
             double presentationTime = Math.Max(earliestPresentationTime, Time.Current);
-
             Scheduler.AddDelayed(presentRemainingCards, presentationTime - Time.Current);
+
+            timeRunningOutSampleChannel?.Stop();
         }
 
         private void presentRemainingCards()
@@ -278,6 +334,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         protected override void Dispose(bool isDisposing)
         {
+            timeRunningOutSampleChannel?.Stop();
+            timeRunningOutSampleChannel?.Dispose();
+
             matchInfo.PlayerCardAdded -= cardAdded;
             matchInfo.PlayerCardRemoved -= cardRemoved;
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -11,6 +12,7 @@ using osu.Framework.Logging;
 using osu.Game.Audio;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Online.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Cards;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osuTK;
@@ -19,6 +21,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class PickScreen : RankedPlaySubScreen
     {
+        // When the 'time running out' warning sample starts to play (in remaining seconds)
+        private const int warning_time_threshold = 10;
+
         public CardRow CenterRow { get; private set; } = null!;
 
         private PlayerCardHand playerHand = null!;
@@ -31,6 +36,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
+
+        private Sample? timeRunningOutSample;
+        private SampleChannel? timeRunningOutSampleChannel;
+        private Sample? timeUpBuzzerSample;
+
+        private DateTimeOffset stageEndTime;
+
+        /// <summary>
+        /// Whether the local user has played a card themselves.
+        /// </summary>
+        private bool hasPlayedCard;
 
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
@@ -83,6 +99,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             cardPlaySamples = new Sample?[card_play_samples];
             for (int i = 0; i < card_play_samples; i++)
                 cardPlaySamples[i] = audio.Samples.Get($@"Multiplayer/Matchmaking/Ranked/card-play-{1 + i}");
+
+            timeRunningOutSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-running-out");
+            timeUpBuzzerSample = audio.Samples.Get(@"Multiplayer/Matchmaking/Ranked/time-up");
         }
 
         protected override void LoadComplete()
@@ -90,19 +109,34 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             base.LoadComplete();
 
             matchInfo.CardPlayed += cardPlayed;
+
+            Client.CountdownStarted += onCountdownStarted;
+            Client.CountdownStopped += onCountdownStopped;
+
+            if (Client.Room != null)
+            {
+                foreach (var countdown in Client.Room.ActiveCountdowns)
+                    onCountdownStarted(countdown);
+            }
         }
 
-        private void onPlayButtonClicked()
+        protected override void Update()
         {
-            var selection = playerHand.Selection.SingleOrDefault();
+            base.Update();
 
-            if (selection != null)
+            TimeSpan remainingTime = stageEndTime - DateTimeOffset.Now;
+
+            if (remainingTime.TotalSeconds < warning_time_threshold)
             {
-                playerHand.SelectionMode = CardSelectionMode.Disabled;
-                Client.PlayCard(selection.Card).FireAndForget();
-            }
+                timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
 
-            playerHand.PlayCardAction = null;
+                if (timeRunningOutSampleChannel == null || timeRunningOutSampleChannel.Playing)
+                    return;
+
+                timeRunningOutSampleChannel.ManualFree = true;
+                timeRunningOutSampleChannel.Looping = true;
+                timeRunningOutSampleChannel.Play();
+            }
         }
 
         public override void OnEntering(RankedPlaySubScreen? previous)
@@ -146,6 +180,37 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             opponentHand.UpdateLayout(stagger: 50);
         }
 
+        private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
+        {
+            if (countdown is not RankedPlayStageCountdown)
+                return;
+
+            stageEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
+        });
+
+        private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
+        {
+            if (countdown is not RankedPlayStageCountdown)
+                return;
+
+            stageEndTime = DateTimeOffset.Now;
+        });
+
+        private void onPlayButtonClicked()
+        {
+            var selection = playerHand.Selection.SingleOrDefault();
+
+            if (selection != null)
+            {
+                hasPlayedCard = true;
+                playerHand.SelectionMode = CardSelectionMode.Disabled;
+
+                Client.PlayCard(selection.Card).FireAndForget();
+            }
+
+            playerHand.PlayCardAction = null;
+        }
+
         private void cardPlayed(RankedPlayCardWithPlaylistItem item)
         {
             RankedPlayCard? card;
@@ -178,10 +243,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             playerHand.Contract();
 
             playerHand.SelectionMode = CardSelectionMode.Disabled;
+
+            timeRunningOutSampleChannel?.Stop();
+
+            if (!hasPlayedCard)
+                timeUpBuzzerSample?.Play();
         }
 
         protected override void Dispose(bool isDisposing)
         {
+            timeRunningOutSampleChannel?.Stop();
+            timeRunningOutSampleChannel?.Dispose();
+
             matchInfo.CardPlayed -= cardPlayed;
 
             base.Dispose(isDisposing);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/PickScreen.cs
@@ -37,6 +37,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private const int card_play_samples = 2;
         private Sample?[]? cardPlaySamples;
 
+        private bool timeRunningOutWarningActive;
         private Sample? timeRunningOutSample;
         private SampleChannel? timeRunningOutSampleChannel;
         private Sample? timeUpBuzzerSample;
@@ -126,7 +127,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             TimeSpan remainingTime = stageEndTime - DateTimeOffset.Now;
 
-            if (remainingTime.TotalSeconds < warning_time_threshold)
+            if (timeRunningOutWarningActive && remainingTime.TotalSeconds < warning_time_threshold)
             {
                 timeRunningOutSampleChannel ??= timeRunningOutSample?.GetChannel();
 
@@ -182,18 +183,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
         private void onCountdownStarted(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            if (countdown is not RankedPlayStageCountdown)
+            if (countdown is not RankedPlayStageCountdown stageCountdown)
                 return;
 
             stageEndTime = DateTimeOffset.Now + countdown.TimeRemaining;
+            timeRunningOutWarningActive = stageCountdown.Stage == RankedPlayStage.CardPlay;
         });
 
         private void onCountdownStopped(MultiplayerCountdown countdown) => Scheduler.Add(() =>
         {
-            if (countdown is not RankedPlayStageCountdown)
+            if (countdown is not RankedPlayStageCountdown stageCountdown)
                 return;
 
+            timeRunningOutSampleChannel?.Stop();
+
             stageEndTime = DateTimeOffset.Now;
+            timeRunningOutWarningActive = false;
+
+            if (stageCountdown.Stage == RankedPlayStage.CardPlay && !hasPlayedCard)
+                timeUpBuzzerSample?.Play();
         });
 
         private void onPlayButtonClicked()
@@ -243,11 +251,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
             playerHand.Contract();
 
             playerHand.SelectionMode = CardSelectionMode.Disabled;
-
-            timeRunningOutSampleChannel?.Stop();
-
-            if (!hasPlayedCard)
-                timeUpBuzzerSample?.Play();
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
I've been doing a few practical tests and here's some things that I noticed:

1. A general crash due to a looping sample.
2. Samples playing in intermediate stages like `FinishCardPlay`/`FinishCardDiscard`/`RoundWarmup`/`Results`, where the countdown exists without any action that the user can take.
3. Samples playing for the opposite user - for example in `CardPlay` stage, the sample should only trigger for the user that can play the card.

In general, (2) and (3) are fixed by moving the samples away from `RankedPlayStageDisplay` (a global component) and into each screen (`PickScreen`/`DiscardScreen`). It's a small copy pasting of relevant code.

Additionally, I've removed the time up buzzer from the discard stage because it feels a little harsh?